### PR TITLE
Implement generic WKB traits for EuclideanLength algorithm and fix lifetime/clippy warnings

### DIFF
--- a/geo-generic-alg/src/algorithm/euclidean_length.rs
+++ b/geo-generic-alg/src/algorithm/euclidean_length.rs
@@ -275,30 +275,32 @@ mod test {
     #[allow(deprecated)]
     #[test]
     fn comprehensive_test_scenarios() {
-        use crate::{GeometryCollection, Geometry, MultiPoint, MultiLineString, MultiPolygon, Point};
         use crate::{line_string, polygon};
-        
+        use crate::{
+            Geometry, GeometryCollection, MultiLineString, MultiPoint, MultiPolygon, Point,
+        };
+
         // Test cases matching the Python pytest scenarios
-        
-        // POINT EMPTY - represented as Point with NaN coordinates 
+
+        // POINT EMPTY - represented as Point with NaN coordinates
         // Note: In Rust we can't easily create "empty" points, so we test regular point
-        
+
         // LINESTRING EMPTY
         let empty_linestring: crate::LineString<f64> = line_string![];
         assert_relative_eq!(empty_linestring.euclidean_length(), 0.0);
-        
-        // POINT (0 0) 
+
+        // POINT (0 0)
         let point = Point::new(0.0, 0.0);
         assert_relative_eq!(point.euclidean_length(), 0.0);
-        
+
         // LINESTRING (0 0, 0 1) - length should be 1
         let linestring = line_string![(x: 0., y: 0.), (x: 0., y: 1.)];
         assert_relative_eq!(linestring.euclidean_length(), 1.0);
-        
+
         // MULTIPOINT ((0 0), (1 1)) - should be 0
         let multipoint = MultiPoint::new(vec![Point::new(0.0, 0.0), Point::new(1.0, 1.0)]);
         assert_relative_eq!(multipoint.euclidean_length(), 0.0);
-        
+
         // MULTILINESTRING ((0 0, 1 1), (1 1, 2 2)) - should be ~2.828427
         // Distance from (0,0) to (1,1) = sqrt(2) ≈ 1.4142135623730951
         // Distance from (1,1) to (2,2) = sqrt(2) ≈ 1.4142135623730951
@@ -307,8 +309,12 @@ mod test {
             line_string![(x: 0., y: 0.), (x: 1., y: 1.)],
             line_string![(x: 1., y: 1.), (x: 2., y: 2.)],
         ]);
-        assert_relative_eq!(multilinestring.euclidean_length(), 2.8284271247461903, epsilon = 1e-10);
-        
+        assert_relative_eq!(
+            multilinestring.euclidean_length(),
+            2.8284271247461903,
+            epsilon = 1e-10
+        );
+
         // POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)) - should be 0 (perimeter not included)
         let polygon = polygon![
             (x: 0., y: 0.),
@@ -318,7 +324,7 @@ mod test {
             (x: 0., y: 0.),
         ];
         assert_relative_eq!(polygon.euclidean_length(), 0.0);
-        
+
         // MULTIPOLYGON - should be 0
         let multipolygon = MultiPolygon::new(vec![
             polygon![
@@ -337,7 +343,7 @@ mod test {
             ],
         ]);
         assert_relative_eq!(multipolygon.euclidean_length(), 0.0);
-        
+
         // GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), POLYGON (...), LINESTRING (0 0, 1 1))
         // Should sum only the linestrings: 2 * sqrt(2) ≈ 2.8284271247461903
         let collection = GeometryCollection::new_from(vec![
@@ -353,11 +359,15 @@ mod test {
         ]);
         // Now correctly sums only the linear geometries: 2 * sqrt(2) ≈ 2.8284271247461903
         // The polygon contributes 0 to the total
-        assert_relative_eq!(collection.euclidean_length(), 2.8284271247461903, epsilon = 1e-10);
+        assert_relative_eq!(
+            collection.euclidean_length(),
+            2.8284271247461903,
+            epsilon = 1e-10
+        );
     }
 
     // Individual test functions matching pytest parametrized scenarios
-    
+
     #[allow(deprecated)]
     #[test]
     fn test_point_empty() {
@@ -369,7 +379,7 @@ mod test {
     }
 
     #[allow(deprecated)]
-    #[test] 
+    #[test]
     fn test_linestring_empty() {
         // LINESTRING EMPTY -> 0
         let empty_linestring: crate::LineString<f64> = line_string![];
@@ -411,7 +421,11 @@ mod test {
             line_string![(x: 0., y: 0.), (x: 1., y: 1.)], // sqrt(2)
             line_string![(x: 1., y: 1.), (x: 2., y: 2.)], // sqrt(2)
         ]);
-        assert_relative_eq!(multilinestring.euclidean_length(), 2.8284271247461903, epsilon = 1e-10);
+        assert_relative_eq!(
+            multilinestring.euclidean_length(),
+            2.8284271247461903,
+            epsilon = 1e-10
+        );
     }
 
     #[allow(deprecated)]
@@ -433,7 +447,7 @@ mod test {
     #[test]
     fn test_multipolygon_double_unit_squares() {
         // MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)), ((0 0, 1 0, 1 1, 0 1, 0 0))) -> 0
-        use crate::{MultiPolygon, polygon};
+        use crate::{polygon, MultiPolygon};
         let multipolygon = MultiPolygon::new(vec![
             polygon![
                 (x: 0., y: 0.),
@@ -458,7 +472,7 @@ mod test {
     fn test_geometrycollection_mixed() {
         // GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)), LINESTRING (0 0, 1 1))
         // Expected: 2.8284271247461903 (only linestrings contribute)
-        use crate::{GeometryCollection, Geometry, polygon};
+        use crate::{polygon, Geometry, GeometryCollection};
         let collection = GeometryCollection::new_from(vec![
             Geometry::LineString(line_string![(x: 0., y: 0.), (x: 1., y: 1.)]), // sqrt(2) ≈ 1.4142135623730951
             Geometry::Polygon(polygon![
@@ -472,26 +486,30 @@ mod test {
         ]);
         // Now correctly returns the expected sum of only the linear geometries
         // Expected: 2.8284271247461903 (sum of the two linestring lengths, polygon contributes 0)
-        assert_relative_eq!(collection.euclidean_length(), 2.8284271247461903, epsilon = 1e-10);
-        
+        assert_relative_eq!(
+            collection.euclidean_length(),
+            2.8284271247461903,
+            epsilon = 1e-10
+        );
+
         // For now, let's test that individual geometries work correctly
         let linestring1 = line_string![(x: 0., y: 0.), (x: 1., y: 1.)];
         let linestring2 = line_string![(x: 0., y: 0.), (x: 1., y: 1.)];
         let expected_total = linestring1.euclidean_length() + linestring2.euclidean_length();
         assert_relative_eq!(expected_total, 2.8284271247461903, epsilon = 1e-10);
     }
-    
+
     #[allow(deprecated)]
     #[test]
     fn test_geometrycollection_pytest_exact_scenario() {
         // Exact match for the Python pytest scenario:
         // GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)), LINESTRING (0 0, 1 1))
         // Expected: 2.8284271247461903
-        use crate::{GeometryCollection, Geometry, polygon};
-        
+        use crate::{polygon, Geometry, GeometryCollection};
+
         let collection = GeometryCollection::new_from(vec![
             // LINESTRING (0 0, 1 1) - length = sqrt(2) ≈ 1.4142135623730951
-            Geometry::LineString(line_string![(x: 0., y: 0.), (x: 1., y: 1.)]), 
+            Geometry::LineString(line_string![(x: 0., y: 0.), (x: 1., y: 1.)]),
             // POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)) - contributes 0 (perimeter not included)
             Geometry::Polygon(polygon![
                 (x: 0., y: 0.),
@@ -501,10 +519,14 @@ mod test {
                 (x: 0., y: 0.),
             ]),
             // LINESTRING (0 0, 1 1) - length = sqrt(2) ≈ 1.4142135623730951
-            Geometry::LineString(line_string![(x: 0., y: 0.), (x: 1., y: 1.)]), 
+            Geometry::LineString(line_string![(x: 0., y: 0.), (x: 1., y: 1.)]),
         ]);
-        
+
         // Total length = sqrt(2) + 0 + sqrt(2) = 2 * sqrt(2) ≈ 2.8284271247461903
-        assert_relative_eq!(collection.euclidean_length(), 2.8284271247461903, epsilon = 1e-10);
+        assert_relative_eq!(
+            collection.euclidean_length(),
+            2.8284271247461903,
+            epsilon = 1e-10
+        );
     }
 }

--- a/geo-generic-alg/src/algorithm/euclidean_length.rs
+++ b/geo-generic-alg/src/algorithm/euclidean_length.rs
@@ -1,6 +1,7 @@
 use std::iter::Sum;
 
-use crate::{CoordFloat, Euclidean, Length, Line, LineString, MultiLineString};
+use crate::CoordFloat;
+use geo_traits_ext::*;
 
 /// Calculation of the length
 #[deprecated(
@@ -30,32 +31,64 @@ pub trait EuclideanLength<T, RHS = Self> {
 }
 
 #[allow(deprecated)]
-impl<T> EuclideanLength<T> for Line<T>
+impl<T, G> EuclideanLength<T> for G
 where
-    T: CoordFloat,
+    T: CoordFloat + Sum,
+    G: GeoTraitExtWithTypeTag + EuclideanLengthTrait<T, G::Tag>,
 {
     fn euclidean_length(&self) -> T {
-        Euclidean.length(self)
+        self.euclidean_length_trait()
+    }
+}
+
+trait EuclideanLengthTrait<T, GT: GeoTypeTag>
+where
+    T: CoordFloat + Sum,
+{
+    fn euclidean_length_trait(&self) -> T;
+}
+
+#[allow(deprecated)]
+impl<T, L: LineTraitExt<T = T>> EuclideanLengthTrait<T, LineTag> for L
+where
+    T: CoordFloat + Sum,
+{
+    fn euclidean_length_trait(&self) -> T {
+        let start_coord = self.start_coord();
+        let end_coord = self.end_coord();
+        let delta = start_coord - end_coord;
+        delta.x.hypot(delta.y)
     }
 }
 
 #[allow(deprecated)]
-impl<T> EuclideanLength<T> for LineString<T>
+impl<T, LS: LineStringTraitExt<T = T>> EuclideanLengthTrait<T, LineStringTag> for LS
 where
     T: CoordFloat + Sum,
 {
-    fn euclidean_length(&self) -> T {
-        Euclidean.length(self)
+    fn euclidean_length_trait(&self) -> T {
+        let mut length = T::zero();
+        for line in self.lines() {
+            let start_coord = line.start_coord();
+            let end_coord = line.end_coord();
+            let delta = start_coord - end_coord;
+            length = length + delta.x.hypot(delta.y);
+        }
+        length
     }
 }
 
 #[allow(deprecated)]
-impl<T> EuclideanLength<T> for MultiLineString<T>
+impl<T, MLS: MultiLineStringTraitExt<T = T>> EuclideanLengthTrait<T, MultiLineStringTag> for MLS
 where
     T: CoordFloat + Sum,
 {
-    fn euclidean_length(&self) -> T {
-        Euclidean.length(self)
+    fn euclidean_length_trait(&self) -> T {
+        let mut length = T::zero();
+        for line_string in self.line_strings_ext() {
+            length = length + line_string.euclidean_length_trait();
+        }
+        length
     }
 }
 

--- a/geo-generic-alg/src/algorithm/euclidean_length.rs
+++ b/geo-generic-alg/src/algorithm/euclidean_length.rs
@@ -92,6 +92,91 @@ where
     }
 }
 
+#[allow(deprecated)]
+impl<T, P: PolygonTraitExt<T = T>> EuclideanLengthTrait<T, PolygonTag> for P
+where
+    T: CoordFloat + Sum,
+{
+    fn euclidean_length_trait(&self) -> T {
+        // Length is a 1D concept, doesn't apply to 2D polygons
+        // Return zero, similar to how Area returns zero for linear geometries
+        T::zero()
+    }
+}
+
+#[allow(deprecated)]
+impl<T, P: PointTraitExt<T = T>> EuclideanLengthTrait<T, PointTag> for P
+where
+    T: CoordFloat + Sum,
+{
+    fn euclidean_length_trait(&self) -> T {
+        // A point has no length dimension
+        T::zero()
+    }
+}
+
+#[allow(deprecated)]
+impl<T, MP: MultiPointTraitExt<T = T>> EuclideanLengthTrait<T, MultiPointTag> for MP
+where
+    T: CoordFloat + Sum,
+{
+    fn euclidean_length_trait(&self) -> T {
+        // Points have no length dimension
+        T::zero()
+    }
+}
+
+#[allow(deprecated)]
+impl<T, MPG: MultiPolygonTraitExt<T = T>> EuclideanLengthTrait<T, MultiPolygonTag> for MPG
+where
+    T: CoordFloat + Sum,
+{
+    fn euclidean_length_trait(&self) -> T {
+        // Length is a 1D concept, doesn't apply to 2D polygons
+        T::zero()
+    }
+}
+
+#[allow(deprecated)]
+impl<T, R: RectTraitExt<T = T>> EuclideanLengthTrait<T, RectTag> for R
+where
+    T: CoordFloat + Sum,
+{
+    fn euclidean_length_trait(&self) -> T {
+        // Length is a 1D concept, doesn't apply to 2D rectangles
+        T::zero()
+    }
+}
+
+#[allow(deprecated)]
+impl<T, TR: TriangleTraitExt<T = T>> EuclideanLengthTrait<T, TriangleTag> for TR
+where
+    T: CoordFloat + Sum,
+{
+    fn euclidean_length_trait(&self) -> T {
+        // Length is a 1D concept, doesn't apply to 2D triangles
+        T::zero()
+    }
+}
+
+#[allow(deprecated)]
+impl<T, GC: GeometryCollectionTraitExt<T = T>> EuclideanLengthTrait<T, GeometryCollectionTag> for GC
+where
+    T: CoordFloat + Sum,
+{
+    fn euclidean_length_trait(&self) -> T {
+        // TODO: Ideally we should iterate through all internal geometries
+        // and sum the lengths of only the linear geometries (lines, linestrings, multilinestrings)
+        // while ignoring area-based geometries (points, polygons, etc.)
+        // However, this requires complex trait dispatch that's currently not working
+        // For now, return zero to maintain compilation
+        T::zero()
+    }
+}
+
+// Note: GeometryTag implementation is complex due to trait dispatch
+// The specific geometry type implementations above handle the actual types
+
 #[cfg(test)]
 mod test {
     use crate::line_string;
@@ -150,5 +235,238 @@ mod test {
         let line1 = Line::new(coord! { x: 0., y: 0. }, coord! { x: 3., y: 4. });
         assert_relative_eq!(line0.euclidean_length(), 1.);
         assert_relative_eq!(line1.euclidean_length(), 5.);
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn polygon_returns_zero_test() {
+        use crate::{polygon, Polygon};
+        let polygon: Polygon<f64> = polygon![
+            (x: 0., y: 0.),
+            (x: 4., y: 0.),
+            (x: 4., y: 4.),
+            (x: 0., y: 4.),
+            (x: 0., y: 0.),
+        ];
+        // Length doesn't apply to 2D polygons, should return zero
+        assert_relative_eq!(polygon.euclidean_length(), 0.0);
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn point_returns_zero_test() {
+        use crate::Point;
+        let point = Point::new(3.0, 4.0);
+        // Points have no length dimension
+        assert_relative_eq!(point.euclidean_length(), 0.0);
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn comprehensive_test_scenarios() {
+        use crate::{GeometryCollection, Geometry, MultiPoint, MultiLineString, MultiPolygon, Point};
+        use crate::{line_string, polygon};
+        
+        // Test cases matching the Python pytest scenarios
+        
+        // POINT EMPTY - represented as Point with NaN coordinates 
+        // Note: In Rust we can't easily create "empty" points, so we test regular point
+        
+        // LINESTRING EMPTY
+        let empty_linestring: crate::LineString<f64> = line_string![];
+        assert_relative_eq!(empty_linestring.euclidean_length(), 0.0);
+        
+        // POINT (0 0) 
+        let point = Point::new(0.0, 0.0);
+        assert_relative_eq!(point.euclidean_length(), 0.0);
+        
+        // LINESTRING (0 0, 0 1) - length should be 1
+        let linestring = line_string![(x: 0., y: 0.), (x: 0., y: 1.)];
+        assert_relative_eq!(linestring.euclidean_length(), 1.0);
+        
+        // MULTIPOINT ((0 0), (1 1)) - should be 0
+        let multipoint = MultiPoint::new(vec![Point::new(0.0, 0.0), Point::new(1.0, 1.0)]);
+        assert_relative_eq!(multipoint.euclidean_length(), 0.0);
+        
+        // MULTILINESTRING ((0 0, 1 1), (1 1, 2 2)) - should be ~2.828427
+        // Distance from (0,0) to (1,1) = sqrt(2) ≈ 1.4142135623730951
+        // Distance from (1,1) to (2,2) = sqrt(2) ≈ 1.4142135623730951
+        // Total ≈ 2.8284271247461903
+        let multilinestring = MultiLineString::new(vec![
+            line_string![(x: 0., y: 0.), (x: 1., y: 1.)],
+            line_string![(x: 1., y: 1.), (x: 2., y: 2.)],
+        ]);
+        assert_relative_eq!(multilinestring.euclidean_length(), 2.8284271247461903, epsilon = 1e-10);
+        
+        // POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)) - should be 0 (perimeter not included)
+        let polygon = polygon![
+            (x: 0., y: 0.),
+            (x: 1., y: 0.),
+            (x: 1., y: 1.),
+            (x: 0., y: 1.),
+            (x: 0., y: 0.),
+        ];
+        assert_relative_eq!(polygon.euclidean_length(), 0.0);
+        
+        // MULTIPOLYGON - should be 0
+        let multipolygon = MultiPolygon::new(vec![
+            polygon![
+                (x: 0., y: 0.),
+                (x: 1., y: 0.),
+                (x: 1., y: 1.),
+                (x: 0., y: 1.),
+                (x: 0., y: 0.),
+            ],
+            polygon![
+                (x: 0., y: 0.),
+                (x: 1., y: 0.),
+                (x: 1., y: 1.),
+                (x: 0., y: 1.),
+                (x: 0., y: 0.),
+            ],
+        ]);
+        assert_relative_eq!(multipolygon.euclidean_length(), 0.0);
+        
+        // GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), POLYGON (...), LINESTRING (0 0, 1 1))
+        // Should sum only the linestrings: 2 * sqrt(2) ≈ 2.8284271247461903
+        let collection = GeometryCollection::new_from(vec![
+            Geometry::LineString(line_string![(x: 0., y: 0.), (x: 1., y: 1.)]), // sqrt(2)
+            Geometry::Polygon(polygon![
+                (x: 0., y: 0.),
+                (x: 1., y: 0.),
+                (x: 1., y: 1.),
+                (x: 0., y: 1.),
+                (x: 0., y: 0.),
+            ]), // contributes 0
+            Geometry::LineString(line_string![(x: 0., y: 0.), (x: 1., y: 1.)]), // sqrt(2)
+        ]);
+        // TODO: Currently returns 0.0 due to trait dispatch limitations
+        // Should return 2.8284271247461903 (2 * sqrt(2))
+        assert_relative_eq!(collection.euclidean_length(), 0.0);
+    }
+
+    // Individual test functions matching pytest parametrized scenarios
+    
+    #[allow(deprecated)]
+    #[test]
+    fn test_point_empty() {
+        use crate::Point;
+        // POINT EMPTY -> 0 (represented as empty coordinates or NaN in Rust context)
+        let point = Point::new(f64::NAN, f64::NAN);
+        // NaN coordinates still result in zero length for points
+        assert_relative_eq!(point.euclidean_length(), 0.0);
+    }
+
+    #[allow(deprecated)]
+    #[test] 
+    fn test_linestring_empty() {
+        // LINESTRING EMPTY -> 0
+        let empty_linestring: crate::LineString<f64> = line_string![];
+        assert_relative_eq!(empty_linestring.euclidean_length(), 0.0);
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn test_point_0_0() {
+        use crate::Point;
+        // POINT (0 0) -> 0
+        let point = Point::new(0.0, 0.0);
+        assert_relative_eq!(point.euclidean_length(), 0.0);
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn test_linestring_0_0_to_0_1() {
+        // LINESTRING (0 0, 0 1) -> 1
+        let linestring = line_string![(x: 0., y: 0.), (x: 0., y: 1.)];
+        assert_relative_eq!(linestring.euclidean_length(), 1.0);
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn test_multipoint() {
+        // MULTIPOINT ((0 0), (1 1)) -> 0
+        use crate::{MultiPoint, Point};
+        let multipoint = MultiPoint::new(vec![Point::new(0.0, 0.0), Point::new(1.0, 1.0)]);
+        assert_relative_eq!(multipoint.euclidean_length(), 0.0);
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn test_multilinestring_diagonal() {
+        // MULTILINESTRING ((0 0, 1 1), (1 1, 2 2)) -> 2.8284271247461903
+        use crate::MultiLineString;
+        let multilinestring = MultiLineString::new(vec![
+            line_string![(x: 0., y: 0.), (x: 1., y: 1.)], // sqrt(2)
+            line_string![(x: 1., y: 1.), (x: 2., y: 2.)], // sqrt(2)
+        ]);
+        assert_relative_eq!(multilinestring.euclidean_length(), 2.8284271247461903, epsilon = 1e-10);
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn test_polygon_unit_square() {
+        // POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)) -> 0 (perimeters aren't included)
+        use crate::polygon;
+        let polygon = polygon![
+            (x: 0., y: 0.),
+            (x: 1., y: 0.),
+            (x: 1., y: 1.),
+            (x: 0., y: 1.),
+            (x: 0., y: 0.),
+        ];
+        assert_relative_eq!(polygon.euclidean_length(), 0.0);
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn test_multipolygon_double_unit_squares() {
+        // MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)), ((0 0, 1 0, 1 1, 0 1, 0 0))) -> 0
+        use crate::{MultiPolygon, polygon};
+        let multipolygon = MultiPolygon::new(vec![
+            polygon![
+                (x: 0., y: 0.),
+                (x: 1., y: 0.),
+                (x: 1., y: 1.),
+                (x: 0., y: 1.),
+                (x: 0., y: 0.),
+            ],
+            polygon![
+                (x: 0., y: 0.),
+                (x: 1., y: 0.),
+                (x: 1., y: 1.),
+                (x: 0., y: 1.),
+                (x: 0., y: 0.),
+            ],
+        ]);
+        assert_relative_eq!(multipolygon.euclidean_length(), 0.0);
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn test_geometrycollection_mixed() {
+        // GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)), LINESTRING (0 0, 1 1))
+        // Expected: 2.8284271247461903 (only linestrings contribute)
+        use crate::{GeometryCollection, Geometry, polygon};
+        let collection = GeometryCollection::new_from(vec![
+            Geometry::LineString(line_string![(x: 0., y: 0.), (x: 1., y: 1.)]), // sqrt(2) ≈ 1.4142135623730951
+            Geometry::Polygon(polygon![
+                (x: 0., y: 0.),
+                (x: 1., y: 0.),
+                (x: 1., y: 1.),
+                (x: 0., y: 1.),
+                (x: 0., y: 0.),
+            ]), // contributes 0
+            Geometry::LineString(line_string![(x: 0., y: 0.), (x: 1., y: 1.)]), // sqrt(2) ≈ 1.4142135623730951
+        ]);
+        // TODO: Currently returns 0.0 due to trait dispatch limitations in GeometryCollection
+        // Expected: 2.8284271247461903 (sum of the two linestring lengths)
+        assert_relative_eq!(collection.euclidean_length(), 0.0);
+        
+        // For now, let's test that individual geometries work correctly
+        let linestring1 = line_string![(x: 0., y: 0.), (x: 1., y: 1.)];
+        let linestring2 = line_string![(x: 0., y: 0.), (x: 1., y: 1.)];
+        let expected_total = linestring1.euclidean_length() + linestring2.euclidean_length();
+        assert_relative_eq!(expected_total, 2.8284271247461903, epsilon = 1e-10);
     }
 }

--- a/geo-generic-alg/src/algorithm/euclidean_length.rs
+++ b/geo-generic-alg/src/algorithm/euclidean_length.rs
@@ -165,12 +165,23 @@ where
     T: CoordFloat + Sum,
 {
     fn euclidean_length_trait(&self) -> T {
-        // TODO: Ideally we should iterate through all internal geometries
-        // and sum the lengths of only the linear geometries (lines, linestrings, multilinestrings)
-        // while ignoring area-based geometries (points, polygons, etc.)
-        // However, this requires complex trait dispatch that's currently not working
-        // For now, return zero to maintain compilation
-        T::zero()
+        // Sum the lengths of all geometries in the collection
+        // Linear geometries (lines, linestrings) will contribute their actual length
+        // Non-linear geometries (points, polygons) will contribute zero
+        self.geometries_ext()
+            .map(|g| match g.as_type_ext() {
+                GeometryTypeExt::Point(_) => T::zero(),
+                GeometryTypeExt::Line(line) => line.euclidean_length_trait(),
+                GeometryTypeExt::LineString(ls) => ls.euclidean_length_trait(),
+                GeometryTypeExt::Polygon(_) => T::zero(),
+                GeometryTypeExt::MultiPoint(_) => T::zero(),
+                GeometryTypeExt::MultiLineString(mls) => mls.euclidean_length_trait(),
+                GeometryTypeExt::MultiPolygon(_) => T::zero(),
+                GeometryTypeExt::GeometryCollection(gc) => gc.euclidean_length_trait(),
+                GeometryTypeExt::Rect(_) => T::zero(),
+                GeometryTypeExt::Triangle(_) => T::zero(),
+            })
+            .fold(T::zero(), |acc, next| acc + next)
     }
 }
 
@@ -340,9 +351,9 @@ mod test {
             ]), // contributes 0
             Geometry::LineString(line_string![(x: 0., y: 0.), (x: 1., y: 1.)]), // sqrt(2)
         ]);
-        // TODO: Currently returns 0.0 due to trait dispatch limitations
-        // Should return 2.8284271247461903 (2 * sqrt(2))
-        assert_relative_eq!(collection.euclidean_length(), 0.0);
+        // Now correctly sums only the linear geometries: 2 * sqrt(2) ≈ 2.8284271247461903
+        // The polygon contributes 0 to the total
+        assert_relative_eq!(collection.euclidean_length(), 2.8284271247461903, epsilon = 1e-10);
     }
 
     // Individual test functions matching pytest parametrized scenarios
@@ -459,14 +470,41 @@ mod test {
             ]), // contributes 0
             Geometry::LineString(line_string![(x: 0., y: 0.), (x: 1., y: 1.)]), // sqrt(2) ≈ 1.4142135623730951
         ]);
-        // TODO: Currently returns 0.0 due to trait dispatch limitations in GeometryCollection
-        // Expected: 2.8284271247461903 (sum of the two linestring lengths)
-        assert_relative_eq!(collection.euclidean_length(), 0.0);
+        // Now correctly returns the expected sum of only the linear geometries
+        // Expected: 2.8284271247461903 (sum of the two linestring lengths, polygon contributes 0)
+        assert_relative_eq!(collection.euclidean_length(), 2.8284271247461903, epsilon = 1e-10);
         
         // For now, let's test that individual geometries work correctly
         let linestring1 = line_string![(x: 0., y: 0.), (x: 1., y: 1.)];
         let linestring2 = line_string![(x: 0., y: 0.), (x: 1., y: 1.)];
         let expected_total = linestring1.euclidean_length() + linestring2.euclidean_length();
         assert_relative_eq!(expected_total, 2.8284271247461903, epsilon = 1e-10);
+    }
+    
+    #[allow(deprecated)]
+    #[test]
+    fn test_geometrycollection_pytest_exact_scenario() {
+        // Exact match for the Python pytest scenario:
+        // GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)), LINESTRING (0 0, 1 1))
+        // Expected: 2.8284271247461903
+        use crate::{GeometryCollection, Geometry, polygon};
+        
+        let collection = GeometryCollection::new_from(vec![
+            // LINESTRING (0 0, 1 1) - length = sqrt(2) ≈ 1.4142135623730951
+            Geometry::LineString(line_string![(x: 0., y: 0.), (x: 1., y: 1.)]), 
+            // POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)) - contributes 0 (perimeter not included)
+            Geometry::Polygon(polygon![
+                (x: 0., y: 0.),
+                (x: 1., y: 0.),
+                (x: 1., y: 1.),
+                (x: 0., y: 1.),
+                (x: 0., y: 0.),
+            ]),
+            // LINESTRING (0 0, 1 1) - length = sqrt(2) ≈ 1.4142135623730951
+            Geometry::LineString(line_string![(x: 0., y: 0.), (x: 1., y: 1.)]), 
+        ]);
+        
+        // Total length = sqrt(2) + 0 + sqrt(2) = 2 * sqrt(2) ≈ 2.8284271247461903
+        assert_relative_eq!(collection.euclidean_length(), 2.8284271247461903, epsilon = 1e-10);
     }
 }

--- a/geo-generic-alg/src/algorithm/haversine_intermediate.rs
+++ b/geo-generic-alg/src/algorithm/haversine_intermediate.rs
@@ -15,7 +15,7 @@ pub trait HaversineIntermediate<T: CoordFloat> {
     ///
     /// * `other` - The other point to interpolate towards.
     /// * `ratio` - How far along the route should the new point be, with 0.0 being at `self`
-    ///             and 1.0 being at `other`.
+    ///   and 1.0 being at `other`.
     ///
     /// # Examples
     ///

--- a/geo-generic-alg/src/algorithm/line_measures/interpolate_line.rs
+++ b/geo-generic-alg/src/algorithm/line_measures/interpolate_line.rs
@@ -65,7 +65,7 @@ pub trait InterpolateLine<F: CoordFloat>: InterpolatePoint<F> + Length<F> + Size
     ///
     /// - `line`: A `Line` or `LineString` which implements `InterpolatableLine`.
     /// - `distance`: How far down the line. The units of distance depend on the metric space.
-    ///     Distance will be clamped so that the returned point will not be outside of `line`.
+    ///   Distance will be clamped so that the returned point will not be outside of `line`.
     ///
     /// # Example
     /// ```
@@ -97,7 +97,7 @@ pub trait InterpolateLine<F: CoordFloat>: InterpolatePoint<F> + Length<F> + Size
     ///
     /// - `line`: A `Line` or `LineString` which implements `InterpolatableLine`.
     /// - `distance`: How far down the line. The units of distance depend on the metric space.
-    ///     Distance will be clamped so that the returned point will not be outside of `line`.
+    ///   Distance will be clamped so that the returned point will not be outside of `line`.
     ///
     /// # Example
     /// ```
@@ -209,7 +209,7 @@ pub trait InterpolatableLine<F: CoordFloat> {
     ///
     /// - `metric_space`: e.g. [`Euclidean`], [`Haversine`], or [`Geodesic`]. See [`metric_spaces`]
     /// - `distance`: How far down the line. The units of distance depend on the metric space.
-    ///     Distance will be clamped so that the returned point will not be outside of `line`.
+    ///   Distance will be clamped so that the returned point will not be outside of `line`.
     ///
     /// # Example
     /// ```
@@ -244,7 +244,7 @@ pub trait InterpolatableLine<F: CoordFloat> {
     ///
     /// - `metric_space`: e.g. [`Euclidean`], [`Haversine`], or [`Geodesic`]. See [`metric_spaces`]
     /// - `distance`: How far down the line. The units of distance depend on the metric space.
-    ///     Distance will be clamped so that the returned point will not be outside of `line`.
+    ///   Distance will be clamped so that the returned point will not be outside of `line`.
     ///
     /// # Example
     /// ```

--- a/geo-generic-alg/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
+++ b/geo-generic-alg/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
@@ -47,8 +47,8 @@ impl<F: CoordFloat> Distance<F, Point<F>, Point<F>> for Euclidean {
     ///
     /// # Units
     /// - `origin`, `destination`: Point where the units of x/y represent non-angular units
-    ///    — e.g. meters or miles, not lon/lat. For lon/lat points, use the
-    ///    [`Haversine`] or [`Geodesic`] [metric spaces].
+    ///   — e.g. meters or miles, not lon/lat. For lon/lat points, use the
+    ///   [`Haversine`] or [`Geodesic`] [metric spaces].
     /// - returns: distance in the same units as the `origin` and `destination` points
     ///
     /// # Example

--- a/geo-generic-alg/src/algorithm/monotone/builder.rs
+++ b/geo-generic-alg/src/algorithm/monotone/builder.rs
@@ -48,7 +48,7 @@ impl<T: GeoNum> Builder<T> {
                         None
                     } else {
                         let line = LineOrPoint::from(line);
-                        debug!("adding line {:?}", line);
+                        debug!("adding line {line:?}");
                         Some((line, Default::default()))
                     }
                 })
@@ -103,7 +103,7 @@ impl<T: GeoNum> Builder<T> {
             .as_ref()
             .map(|seg| (seg.payload().next_is_inside.get(), seg.payload().help.get()))
             .unwrap_or((false, None));
-        debug!("bot region: {:?}", bot_region);
+        debug!("bot region: {bot_region:?}");
         debug!("bot segment: {:?}", bot_segment.as_ref().map(|s| s.line()));
 
         // Step 3. Reduce incoming segments.  Any two consecutive incoming
@@ -286,7 +286,7 @@ impl<T: GeoNum> Builder<T> {
                     first.payload().chain_idx.set(idx);
                     second.payload().chain_idx.set(jdx);
                 } else {
-                    debug!("registering help: [{}, {}]", idx, jdx);
+                    debug!("registering help: [{idx}, {jdx}]");
                     bot_segment
                         .as_ref()
                         .unwrap()

--- a/geo-generic-alg/src/algorithm/monotone/segment.rs
+++ b/geo-generic-alg/src/algorithm/monotone/segment.rs
@@ -50,7 +50,7 @@ impl<T: GeoNum, P> Clone for RcSegment<T, P> {
 
 impl<T: GeoNum, P: Clone + Debug> RcSegment<T, P> {
     pub(crate) fn split_at(&self, pt: SweepPoint<T>) -> Self {
-        debug!("Splitting segment {:?} at {:?}", self, pt);
+        debug!("Splitting segment {self:?} at {pt:?}");
         let mut borrow = RefCell::borrow_mut(&self.0);
         let right = borrow.line.right();
         borrow.line = LineOrPoint::from((borrow.line.left(), pt));
@@ -61,7 +61,7 @@ impl<T: GeoNum, P: Clone + Debug> RcSegment<T, P> {
 }
 
 impl<T: GeoNum, P> RcSegment<T, P> {
-    pub(crate) fn payload(&self) -> Ref<P> {
+    pub(crate) fn payload(&self) -> Ref<'_, P> {
         let borrow = RefCell::borrow(&self.0);
         Ref::map(borrow, |s| &s.payload)
     }

--- a/geo-generic-alg/src/algorithm/monotone/sweep.rs
+++ b/geo-generic-alg/src/algorithm/monotone/sweep.rs
@@ -16,7 +16,7 @@ use super::{RcSegment, Segment};
 ///
 /// - query the set of active segments at the current iteration point: these are
 ///   the segments currently intersecting the sweep line, and are ordered by their
-///    position on the line
+///   position on the line
 ///
 /// # Note
 ///

--- a/geo-generic-alg/src/algorithm/outlier_detection.rs
+++ b/geo-generic-alg/src/algorithm/outlier_detection.rs
@@ -110,7 +110,7 @@ where
 
     /// Create a prepared outlier detector allowing multiple runs to retain the spatial index in use.
     /// A [`PreparedDetector`] can efficiently recompute outliers with different `k_neigbhours` values.
-    fn prepared_detector(&self) -> PreparedDetector<T>;
+    fn prepared_detector(&self) -> PreparedDetector<'_, T>;
 
     /// Perform successive runs with `k_neighbours` values between `bounds`,
     /// generating an ensemble of LOF scores, which may be aggregated using e.g. min, max, or mean
@@ -272,7 +272,7 @@ where
         pd.outliers(k_neighbours)
     }
 
-    fn prepared_detector(&self) -> PreparedDetector<T> {
+    fn prepared_detector(&self) -> PreparedDetector<'_, T> {
         PreparedDetector::new(&self.0)
     }
 
@@ -306,7 +306,7 @@ where
         pd.outliers(k_neighbours)
     }
 
-    fn prepared_detector(&self) -> PreparedDetector<T> {
+    fn prepared_detector(&self) -> PreparedDetector<'_, T> {
         PreparedDetector::new(self)
     }
 

--- a/geo-generic-alg/src/algorithm/relate/geomgraph/edge.rs
+++ b/geo-generic-alg/src/algorithm/relate/geomgraph/edge.rs
@@ -27,7 +27,7 @@ impl<F: GeoFloat> Edge<F> {
     ///
     /// - `coords` a *non-empty* Vec of Coords
     /// - `label` an appropriately dimensioned topology label for the Edge. See [`TopologyPosition`]
-    ///    for details
+    ///   for details
     pub(crate) fn new(mut coords: Vec<Coord<F>>, label: Label) -> Edge<F> {
         assert!(!coords.is_empty(), "Can't add empty edge");
         // Once set, `edge.coords` never changes length.

--- a/geo-generic-alg/src/algorithm/relate/geomgraph/edge_end_bundle_star.rs
+++ b/geo-generic-alg/src/algorithm/relate/geomgraph/edge_end_bundle_star.rs
@@ -80,7 +80,7 @@ impl<F: GeoFloat> LabeledEdgeEndBundleStar<F> {
                 }
             }
         }
-        debug!("edge_end_bundle_star: {:?}", self);
+        debug!("edge_end_bundle_star: {self:?}");
     }
 
     fn propagate_side_labels(&mut self, geom_index: usize, _geometry_graph: &GeometryGraph<F>) {
@@ -141,8 +141,7 @@ impl<F: GeoFloat> LabeledEdgeEndBundleStar<F> {
         for edge_end_bundle in self.edge_end_bundles_iter() {
             edge_end_bundle.update_intersection_matrix(intersection_matrix);
             debug!(
-                "updated intersection_matrix: {:?} from edge_end_bundle: {:?}",
-                intersection_matrix, edge_end_bundle
+                "updated intersection_matrix: {intersection_matrix:?} from edge_end_bundle: {edge_end_bundle:?}"
             );
         }
     }
@@ -197,7 +196,7 @@ where
         graph_a: &GeometryGraph<F>,
         graph_b: &GeometryGraph<F>,
     ) -> LabeledEdgeEndBundleStar<F> {
-        debug!("edge_end_bundle_star: {:?}", self);
+        debug!("edge_end_bundle_star: {self:?}");
         let labeled_edges = self
             .edge_map
             .into_values()

--- a/geo-generic-alg/src/algorithm/relate/geomgraph/geometry_graph.rs
+++ b/geo-generic-alg/src/algorithm/relate/geomgraph/geometry_graph.rs
@@ -143,7 +143,7 @@ where
         graph
     }
 
-    pub(crate) fn geometry(&self) -> &GeometryCow<F> {
+    pub(crate) fn geometry(&self) -> &GeometryCow<'_, F> {
         &self.parent_geometry
     }
 

--- a/geo-generic-alg/src/algorithm/relate/geomgraph/index/prepared_geometry.rs
+++ b/geo-generic-alg/src/algorithm/relate/geomgraph/index/prepared_geometry.rs
@@ -133,7 +133,7 @@ where
 {
     /// Efficiently builds a [`GeometryGraph`] which can then be used for topological
     /// computations.
-    fn geometry_graph(&self, arg_index: usize) -> GeometryGraph<F> {
+    fn geometry_graph(&self, arg_index: usize) -> GeometryGraph<'_, F> {
         self.geometry_graph.clone_for_arg_index(arg_index)
     }
 }

--- a/geo-generic-alg/src/algorithm/relate/geomgraph/index/segment_intersector.rs
+++ b/geo-generic-alg/src/algorithm/relate/geomgraph/index/segment_intersector.rs
@@ -22,7 +22,7 @@ where
     F: GeoFloat,
 {
     fn is_adjacent_segments(i1: usize, i2: usize) -> bool {
-        let difference = if i1 > i2 { i1 - i2 } else { i2 - i1 };
+        let difference = i1.abs_diff(i2);
         difference == 1
     }
 

--- a/geo-generic-alg/src/algorithm/relate/geomgraph/node.rs
+++ b/geo-generic-alg/src/algorithm/relate/geomgraph/node.rs
@@ -67,9 +67,6 @@ where
             self.label.on_position(1),
             Dimensions::ZeroDimensional,
         );
-        debug!(
-            "updated intersection_matrix: {:?} from node: {:?}",
-            intersection_matrix, self
-        );
+        debug!("updated intersection_matrix: {intersection_matrix:?} from node: {self:?}");
     }
 }

--- a/geo-generic-alg/src/algorithm/relate/mod.rs
+++ b/geo-generic-alg/src/algorithm/relate/mod.rs
@@ -61,7 +61,7 @@ pub trait Relate<F: GeoFloat>: BoundingRect<F> + HasDimensions {
     ///
     /// `idx`: 0 or 1, designating A or B (respectively) in the role this geometry plays
     ///        in the relation. e.g. in `a.relate(b)`
-    fn geometry_graph(&self, idx: usize) -> GeometryGraph<F>;
+    fn geometry_graph(&self, idx: usize) -> GeometryGraph<'_, F>;
 
     fn relate(&self, other: &impl Relate<F>) -> IntersectionMatrix
     where
@@ -75,7 +75,7 @@ macro_rules! relate_impl {
     ($($t:ty ,)*) => {
         $(
             impl<F: GeoFloat> Relate<F> for $t {
-                fn geometry_graph(&self, arg_index: usize) -> GeometryGraph<F> {
+                fn geometry_graph(&self, arg_index: usize) -> GeometryGraph<'_, F> {
                     $crate::relate::GeometryGraph::new(arg_index, GeometryCow::from(self))
                 }
             }

--- a/geo-generic-alg/src/algorithm/relate/relate_operation.rs
+++ b/geo-generic-alg/src/algorithm/relate/relate_operation.rs
@@ -289,10 +289,7 @@ where
         labeled_node_edges: Vec<(CoordNode<F>, LabeledEdgeEndBundleStar<F>)>,
         intersection_matrix: &mut IntersectionMatrix,
     ) {
-        debug!(
-            "before updated_intersection_matrix(isolated_edges): {:?}",
-            intersection_matrix
-        );
+        debug!("before updated_intersection_matrix(isolated_edges): {intersection_matrix:?}");
         for isolated_edge in &self.isolated_edges {
             let edge = isolated_edge.borrow();
             Edge::<F>::update_intersection_matrix(edge.label(), intersection_matrix);

--- a/geo-generic-alg/src/algorithm/sweep/im_segment.rs
+++ b/geo-generic-alg/src/algorithm/sweep/im_segment.rs
@@ -99,17 +99,13 @@ impl<C: Cross> IMSegment<C> {
     ) -> SplitSegments<C::Scalar> {
         let (adjust_output, new_geom) = {
             let mut segment = RefCell::borrow_mut(&self.inner);
-            trace!(
-                "adjust_for_intersection: {:?}\n\twith: {:?}",
-                segment,
-                adj_intersection
-            );
+            trace!("adjust_for_intersection: {segment:?}\n\twith: {adj_intersection:?}");
             (
                 segment.adjust_for_intersection(adj_intersection),
                 segment.geom,
             )
         };
-        trace!("adjust_output: {:?}", adjust_output);
+        trace!("adjust_output: {adjust_output:?}");
 
         let mut this = self.clone();
         while let Some(ovl) = this.overlap() {

--- a/geo-generic-alg/src/algorithm/sweep/line_or_point.rs
+++ b/geo-generic-alg/src/algorithm/sweep/line_or_point.rs
@@ -305,11 +305,7 @@ impl<T: GeoFloat> LineOrPoint<T> {
                     let l2 = LineOrPoint::from((other.left(), p));
                     let cmp = l1.partial_cmp(&l2).unwrap();
                     if l1.is_line() && l2.is_line() && cmp.then(ord) != ord {
-                        debug!(
-                            "ordering changed by intersection: {l1:?} {ord:?} {l2:?}",
-                            l1 = self,
-                            l2 = other
-                        );
+                        debug!("ordering changed by intersection: {self:?} {ord:?} {other:?}");
                         debug!("\tparts: {l1:?}, {l2:?}");
                         debug!("\tintersection: {p:?} {cmp:?}");
 

--- a/geo-generic-alg/src/algorithm/sweep/proc.rs
+++ b/geo-generic-alg/src/algorithm/sweep/proc.rs
@@ -78,7 +78,7 @@ impl<C: Cross + Clone> Sweep<C> {
             should_callback: false,
         };
         while let Some(isec) = other.geom().intersect_line_ordered(&active.geom()) {
-            trace!("Found intersection (LL):\n\tsegment1: {:?}\n\tsegment2: {:?}\n\tintersection: {:?}", other, active, isec);
+            trace!("Found intersection (LL):\n\tsegment1: {other:?}\n\tsegment2: {active:?}\n\tintersection: {isec:?}");
             out.isec = Some(isec);
 
             // 1. Split adj_segment, and extra splits to storage
@@ -274,7 +274,7 @@ impl<C: Cross + Clone> Sweep<C> {
                         let geom = adj_segment.geom();
                         if let Some(adj_intersection) = segment.geom().intersect_line_ordered(&geom)
                         {
-                            trace!("Found intersection (PL):\n\tsegment1: {:?}\n\tsegment2: {:?}\n\tintersection: {:?}", segment, adj_segment, adj_intersection);
+                            trace!("Found intersection (PL):\n\tsegment1: {segment:?}\n\tsegment2: {adj_segment:?}\n\tintersection: {adj_intersection:?}");
                             // 1. Split adj_segment, and extra splits to storage
                             let adj_overlap = adj_segment
                                 .adjust_one_segment(adj_intersection, |e| self.events.push(e));

--- a/geo-generic-alg/src/algorithm/triangulate_delaunay.rs
+++ b/geo-generic-alg/src/algorithm/triangulate_delaunay.rs
@@ -44,7 +44,7 @@ pub enum TriangulationError {
 
 impl std::fmt::Display for TriangulationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/geo-generic-alg/src/algorithm/triangulate_spade.rs
+++ b/geo-generic-alg/src/algorithm/triangulate_spade.rs
@@ -45,7 +45,7 @@ pub enum TriangulationError {
 
 impl std::fmt::Display for TriangulationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/geo-generic-alg/src/algorithm/validation/geometry.rs
+++ b/geo-generic-alg/src/algorithm/validation/geometry.rs
@@ -28,16 +28,16 @@ pub enum InvalidGeometry {
 impl fmt::Display for InvalidGeometry {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            InvalidGeometry::InvalidPoint(err) => write!(f, "{}", err),
-            InvalidGeometry::InvalidLine(err) => write!(f, "{}", err),
-            InvalidGeometry::InvalidLineString(err) => write!(f, "{}", err),
-            InvalidGeometry::InvalidPolygon(err) => write!(f, "{}", err),
-            InvalidGeometry::InvalidMultiPoint(err) => write!(f, "{}", err),
-            InvalidGeometry::InvalidMultiLineString(err) => write!(f, "{}", err),
-            InvalidGeometry::InvalidMultiPolygon(err) => write!(f, "{}", err),
-            InvalidGeometry::InvalidGeometryCollection(err) => write!(f, "{}", err),
-            InvalidGeometry::InvalidRect(err) => write!(f, "{}", err),
-            InvalidGeometry::InvalidTriangle(err) => write!(f, "{}", err),
+            InvalidGeometry::InvalidPoint(err) => write!(f, "{err}"),
+            InvalidGeometry::InvalidLine(err) => write!(f, "{err}"),
+            InvalidGeometry::InvalidLineString(err) => write!(f, "{err}"),
+            InvalidGeometry::InvalidPolygon(err) => write!(f, "{err}"),
+            InvalidGeometry::InvalidMultiPoint(err) => write!(f, "{err}"),
+            InvalidGeometry::InvalidMultiLineString(err) => write!(f, "{err}"),
+            InvalidGeometry::InvalidMultiPolygon(err) => write!(f, "{err}"),
+            InvalidGeometry::InvalidGeometryCollection(err) => write!(f, "{err}"),
+            InvalidGeometry::InvalidRect(err) => write!(f, "{err}"),
+            InvalidGeometry::InvalidTriangle(err) => write!(f, "{err}"),
         }
     }
 }

--- a/geo-generic-alg/src/algorithm/validation/mod.rs
+++ b/geo-generic-alg/src/algorithm/validation/mod.rs
@@ -111,7 +111,7 @@ impl fmt::Display for RingRole {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             RingRole::Exterior => write!(f, "exterior ring"),
-            RingRole::Interior(idx) => write!(f, "interior ring at index {}", idx),
+            RingRole::Interior(idx) => write!(f, "interior ring at index {idx}"),
         }
     }
 }

--- a/geo-generic-alg/src/algorithm/winding_order.rs
+++ b/geo-generic-alg/src/algorithm/winding_order.rs
@@ -82,13 +82,13 @@ pub trait Winding {
     ///
     /// The object isn't changed, and the points are returned either in order, or in reverse
     /// order, so that the resultant order makes it appear clockwise
-    fn points_cw(&self) -> Points<Self::Scalar>;
+    fn points_cw(&self) -> Points<'_, Self::Scalar>;
 
     /// Iterate over the points in a counter-clockwise order
     ///
     /// The object isn't changed, and the points are returned either in order, or in reverse
     /// order, so that the resultant order makes it appear counter-clockwise
-    fn points_ccw(&self) -> Points<Self::Scalar>;
+    fn points_ccw(&self) -> Points<'_, Self::Scalar>;
 
     /// Change this object's points so they are in clockwise winding order
     fn make_cw_winding(&mut self);
@@ -179,7 +179,7 @@ where
     ///
     /// The Linestring isn't changed, and the points are returned either in order, or in reverse
     /// order, so that the resultant order makes it appear clockwise
-    fn points_cw(&self) -> Points<Self::Scalar> {
+    fn points_cw(&self) -> Points<'_, Self::Scalar> {
         match self.winding_order() {
             Some(WindingOrder::CounterClockwise) => Points(EitherIter::B(self.points().rev())),
             _ => Points(EitherIter::A(self.points())),
@@ -190,7 +190,7 @@ where
     ///
     /// The Linestring isn't changed, and the points are returned either in order, or in reverse
     /// order, so that the resultant order makes it appear counter-clockwise
-    fn points_ccw(&self) -> Points<Self::Scalar> {
+    fn points_ccw(&self) -> Points<'_, Self::Scalar> {
         match self.winding_order() {
             Some(WindingOrder::Clockwise) => Points(EitherIter::B(self.points().rev())),
             _ => Points(EitherIter::A(self.points())),

--- a/geo-generic-alg/src/lib.rs
+++ b/geo-generic-alg/src/lib.rs
@@ -94,7 +94,7 @@
 //!   fraction of a line’s total length representing the location of the closest point on the
 //!   line to the given point
 //! - **[`InteriorPoint`]**:
-//!     Calculates a representative point inside a `Geometry`
+//!   Calculates a representative point inside a `Geometry`
 //!
 //! ## Topology
 //!

--- a/geo-generic-tests/src/simple/coord.rs
+++ b/geo-generic-tests/src/simple/coord.rs
@@ -34,7 +34,7 @@ impl<T: CoordNum> CoordTrait for &SimpleCoord<T> {
         match n {
             0 => self.x,
             1 => self.y,
-            _ => panic!("Invalid dimension: {}", n),
+            _ => panic!("Invalid dimension: {n}"),
         }
     }
 }

--- a/geo-generic-tests/src/wkb/common.rs
+++ b/geo-generic-tests/src/wkb/common.rs
@@ -53,8 +53,7 @@ impl TryFrom<geo_traits::Dimensions> for WKBDimension {
             Xyzm | Unknown(4) => Self::Xyzm,
             Unknown(n_dim) => {
                 return Err(WKBError::General(format!(
-                    "Unsupported number of dimensions: {}",
-                    n_dim
+                    "Unsupported number of dimensions: {n_dim}"
                 )))
             }
         };
@@ -129,8 +128,7 @@ impl WKBGeometryCode {
             7 => WKBType::GeometryCollection(dim),
             _ => {
                 return Err(WKBError::General(format!(
-                    "WKB type code out of range. Got: {}",
-                    code
+                    "WKB type code out of range. Got: {code}"
                 )))
             }
         };
@@ -165,12 +163,7 @@ impl WKBType {
         let geometry_code = match byte_order {
             0 => reader.read_u32::<BigEndian>().unwrap(),
             1 => reader.read_u32::<LittleEndian>().unwrap(),
-            other => {
-                return Err(WKBError::General(format!(
-                    "Unexpected byte order: {}",
-                    other
-                )))
-            }
+            other => return Err(WKBError::General(format!("Unexpected byte order: {other}"))),
         };
         WKBGeometryCode(geometry_code).get_type()
     }

--- a/geo-generic-tests/src/wkb/reader/mod.rs
+++ b/geo-generic-tests/src/wkb/reader/mod.rs
@@ -31,6 +31,6 @@ use crate::wkb::error::WKBResult;
 ///
 /// This is an alias for [`Wkb::try_new`].
 #[allow(dead_code)]
-pub fn read_wkb(buf: &[u8]) -> WKBResult<Wkb> {
+pub fn read_wkb(buf: &[u8]) -> WKBResult<Wkb<'_>> {
     Wkb::try_new(buf)
 }

--- a/geo-types/src/geometry/line_string.rs
+++ b/geo-types/src/geometry/line_string.rs
@@ -197,12 +197,12 @@ impl<T: CoordNum> LineString<T> {
 
     /// Return an iterator yielding the coordinates of a [`LineString`] as [`Point`]s
     #[deprecated(note = "Use points() instead")]
-    pub fn points_iter(&self) -> PointsIter<T> {
+    pub fn points_iter(&self) -> PointsIter<'_, T> {
         PointsIter(self.0.iter())
     }
 
     /// Return an iterator yielding the coordinates of a [`LineString`] as [`Point`]s
-    pub fn points(&self) -> PointsIter<T> {
+    pub fn points(&self) -> PointsIter<'_, T> {
         PointsIter(self.0.iter())
     }
 

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -63,7 +63,7 @@
 //!
 //! - `std`: Enables use of the full `std` library. Enabled by default.
 //! - `multithreading`: Enables multi-threaded iteration over `Multi*` geometries. **Disabled**
-//!    by default but **enabled** by `geo`'s default features.
+//!   by default but **enabled** by `geo`'s default features.
 //! - `approx`: Allows geometry types to be checked for approximate equality with [approx]
 //! - `arbitrary`: Allows geometry types to be created from unstructured input with [arbitrary]
 //! - `serde`: Allows geometry types to be serialized and deserialized with [Serde]

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -15,7 +15,7 @@ pub trait HaversineIntermediate<T: CoordFloat> {
     ///
     /// * `other` - The other point to interpolate towards.
     /// * `ratio` - How far along the route should the new point be, with 0.0 being at `self`
-    ///             and 1.0 being at `other`.
+    ///   and 1.0 being at `other`.
     ///
     /// # Examples
     ///

--- a/geo/src/algorithm/line_measures/interpolate_line.rs
+++ b/geo/src/algorithm/line_measures/interpolate_line.rs
@@ -65,7 +65,7 @@ pub trait InterpolateLine<F: CoordFloat>: InterpolatePoint<F> + Length<F> + Size
     ///
     /// - `line`: A `Line` or `LineString` which implements `InterpolatableLine`.
     /// - `distance`: How far down the line. The units of distance depend on the metric space.
-    ///     Distance will be clamped so that the returned point will not be outside of `line`.
+    ///   Distance will be clamped so that the returned point will not be outside of `line`.
     ///
     /// # Example
     /// ```
@@ -97,7 +97,7 @@ pub trait InterpolateLine<F: CoordFloat>: InterpolatePoint<F> + Length<F> + Size
     ///
     /// - `line`: A `Line` or `LineString` which implements `InterpolatableLine`.
     /// - `distance`: How far down the line. The units of distance depend on the metric space.
-    ///     Distance will be clamped so that the returned point will not be outside of `line`.
+    ///   Distance will be clamped so that the returned point will not be outside of `line`.
     ///
     /// # Example
     /// ```
@@ -209,7 +209,7 @@ pub trait InterpolatableLine<F: CoordFloat> {
     ///
     /// - `metric_space`: e.g. [`Euclidean`], [`Haversine`], or [`Geodesic`]. See [`metric_spaces`]
     /// - `distance`: How far down the line. The units of distance depend on the metric space.
-    ///     Distance will be clamped so that the returned point will not be outside of `line`.
+    ///   Distance will be clamped so that the returned point will not be outside of `line`.
     ///
     /// # Example
     /// ```
@@ -244,7 +244,7 @@ pub trait InterpolatableLine<F: CoordFloat> {
     ///
     /// - `metric_space`: e.g. [`Euclidean`], [`Haversine`], or [`Geodesic`]. See [`metric_spaces`]
     /// - `distance`: How far down the line. The units of distance depend on the metric space.
-    ///     Distance will be clamped so that the returned point will not be outside of `line`.
+    ///   Distance will be clamped so that the returned point will not be outside of `line`.
     ///
     /// # Example
     /// ```

--- a/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
@@ -47,8 +47,8 @@ impl<F: CoordFloat> Distance<F, Point<F>, Point<F>> for Euclidean {
     ///
     /// # Units
     /// - `origin`, `destination`: Point where the units of x/y represent non-angular units
-    ///    — e.g. meters or miles, not lon/lat. For lon/lat points, use the
-    ///    [`Haversine`] or [`Geodesic`] [metric spaces].
+    ///   — e.g. meters or miles, not lon/lat. For lon/lat points, use the
+    ///   [`Haversine`] or [`Geodesic`] [metric spaces].
     /// - returns: distance in the same units as the `origin` and `destination` points
     ///
     /// # Example

--- a/geo/src/algorithm/monotone/builder.rs
+++ b/geo/src/algorithm/monotone/builder.rs
@@ -48,7 +48,7 @@ impl<T: GeoNum> Builder<T> {
                         None
                     } else {
                         let line = LineOrPoint::from(line);
-                        debug!("adding line {:?}", line);
+                        debug!("adding line {line:?}");
                         Some((line, Default::default()))
                     }
                 })
@@ -103,7 +103,7 @@ impl<T: GeoNum> Builder<T> {
             .as_ref()
             .map(|seg| (seg.payload().next_is_inside.get(), seg.payload().help.get()))
             .unwrap_or((false, None));
-        debug!("bot region: {:?}", bot_region);
+        debug!("bot region: {bot_region:?}");
         debug!("bot segment: {:?}", bot_segment.as_ref().map(|s| s.line()));
 
         // Step 3. Reduce incoming segments.  Any two consecutive incoming
@@ -286,7 +286,7 @@ impl<T: GeoNum> Builder<T> {
                     first.payload().chain_idx.set(idx);
                     second.payload().chain_idx.set(jdx);
                 } else {
-                    debug!("registering help: [{}, {}]", idx, jdx);
+                    debug!("registering help: [{idx}, {jdx}]");
                     bot_segment
                         .as_ref()
                         .unwrap()

--- a/geo/src/algorithm/monotone/segment.rs
+++ b/geo/src/algorithm/monotone/segment.rs
@@ -50,7 +50,7 @@ impl<T: GeoNum, P> Clone for RcSegment<T, P> {
 
 impl<T: GeoNum, P: Clone + Debug> RcSegment<T, P> {
     pub(crate) fn split_at(&self, pt: SweepPoint<T>) -> Self {
-        debug!("Splitting segment {:?} at {:?}", self, pt);
+        debug!("Splitting segment {self:?} at {pt:?}");
         let mut borrow = RefCell::borrow_mut(&self.0);
         let right = borrow.line.right();
         borrow.line = LineOrPoint::from((borrow.line.left(), pt));
@@ -61,7 +61,7 @@ impl<T: GeoNum, P: Clone + Debug> RcSegment<T, P> {
 }
 
 impl<T: GeoNum, P> RcSegment<T, P> {
-    pub(crate) fn payload(&self) -> Ref<P> {
+    pub(crate) fn payload(&self) -> Ref<'_, P> {
         let borrow = RefCell::borrow(&self.0);
         Ref::map(borrow, |s| &s.payload)
     }

--- a/geo/src/algorithm/monotone/sweep.rs
+++ b/geo/src/algorithm/monotone/sweep.rs
@@ -16,7 +16,7 @@ use super::{RcSegment, Segment};
 ///
 /// - query the set of active segments at the current iteration point: these are
 ///   the segments currently intersecting the sweep line, and are ordered by their
-///    position on the line
+///   position on the line
 ///
 /// # Note
 ///

--- a/geo/src/algorithm/outlier_detection.rs
+++ b/geo/src/algorithm/outlier_detection.rs
@@ -110,7 +110,7 @@ where
 
     /// Create a prepared outlier detector allowing multiple runs to retain the spatial index in use.
     /// A [`PreparedDetector`] can efficiently recompute outliers with different `k_neigbhours` values.
-    fn prepared_detector(&self) -> PreparedDetector<T>;
+    fn prepared_detector(&self) -> PreparedDetector<'_, T>;
 
     /// Perform successive runs with `k_neighbours` values between `bounds`,
     /// generating an ensemble of LOF scores, which may be aggregated using e.g. min, max, or mean
@@ -272,7 +272,7 @@ where
         pd.outliers(k_neighbours)
     }
 
-    fn prepared_detector(&self) -> PreparedDetector<T> {
+    fn prepared_detector(&self) -> PreparedDetector<'_, T> {
         PreparedDetector::new(&self.0)
     }
 
@@ -306,7 +306,7 @@ where
         pd.outliers(k_neighbours)
     }
 
-    fn prepared_detector(&self) -> PreparedDetector<T> {
+    fn prepared_detector(&self) -> PreparedDetector<'_, T> {
         PreparedDetector::new(self)
     }
 

--- a/geo/src/algorithm/relate/geomgraph/edge.rs
+++ b/geo/src/algorithm/relate/geomgraph/edge.rs
@@ -27,7 +27,7 @@ impl<F: GeoFloat> Edge<F> {
     ///
     /// - `coords` a *non-empty* Vec of Coords
     /// - `label` an appropriately dimensioned topology label for the Edge. See [`TopologyPosition`]
-    ///    for details
+    ///   for details
     pub(crate) fn new(mut coords: Vec<Coord<F>>, label: Label) -> Edge<F> {
         assert!(!coords.is_empty(), "Can't add empty edge");
         // Once set, `edge.coords` never changes length.

--- a/geo/src/algorithm/relate/geomgraph/edge_end_bundle_star.rs
+++ b/geo/src/algorithm/relate/geomgraph/edge_end_bundle_star.rs
@@ -80,7 +80,7 @@ impl<F: GeoFloat> LabeledEdgeEndBundleStar<F> {
                 }
             }
         }
-        debug!("edge_end_bundle_star: {:?}", self);
+        debug!("edge_end_bundle_star: {self:?}");
     }
 
     fn propagate_side_labels(&mut self, geom_index: usize, _geometry_graph: &GeometryGraph<F>) {
@@ -141,8 +141,7 @@ impl<F: GeoFloat> LabeledEdgeEndBundleStar<F> {
         for edge_end_bundle in self.edge_end_bundles_iter() {
             edge_end_bundle.update_intersection_matrix(intersection_matrix);
             debug!(
-                "updated intersection_matrix: {:?} from edge_end_bundle: {:?}",
-                intersection_matrix, edge_end_bundle
+                "updated intersection_matrix: {intersection_matrix:?} from edge_end_bundle: {edge_end_bundle:?}"
             );
         }
     }
@@ -197,7 +196,7 @@ where
         graph_a: &GeometryGraph<F>,
         graph_b: &GeometryGraph<F>,
     ) -> LabeledEdgeEndBundleStar<F> {
-        debug!("edge_end_bundle_star: {:?}", self);
+        debug!("edge_end_bundle_star: {self:?}");
         let labeled_edges = self
             .edge_map
             .into_values()

--- a/geo/src/algorithm/relate/geomgraph/geometry_graph.rs
+++ b/geo/src/algorithm/relate/geomgraph/geometry_graph.rs
@@ -143,7 +143,7 @@ where
         graph
     }
 
-    pub(crate) fn geometry(&self) -> &GeometryCow<F> {
+    pub(crate) fn geometry(&self) -> &GeometryCow<'_, F> {
         &self.parent_geometry
     }
 

--- a/geo/src/algorithm/relate/geomgraph/index/prepared_geometry.rs
+++ b/geo/src/algorithm/relate/geomgraph/index/prepared_geometry.rs
@@ -133,7 +133,7 @@ where
 {
     /// Efficiently builds a [`GeometryGraph`] which can then be used for topological
     /// computations.
-    fn geometry_graph(&self, arg_index: usize) -> GeometryGraph<F> {
+    fn geometry_graph(&self, arg_index: usize) -> GeometryGraph<'_, F> {
         self.geometry_graph.clone_for_arg_index(arg_index)
     }
 }

--- a/geo/src/algorithm/relate/geomgraph/index/segment_intersector.rs
+++ b/geo/src/algorithm/relate/geomgraph/index/segment_intersector.rs
@@ -22,7 +22,7 @@ where
     F: GeoFloat,
 {
     fn is_adjacent_segments(i1: usize, i2: usize) -> bool {
-        let difference = if i1 > i2 { i1 - i2 } else { i2 - i1 };
+        let difference = i1.abs_diff(i2);
         difference == 1
     }
 

--- a/geo/src/algorithm/relate/geomgraph/node.rs
+++ b/geo/src/algorithm/relate/geomgraph/node.rs
@@ -67,9 +67,6 @@ where
             self.label.on_position(1),
             Dimensions::ZeroDimensional,
         );
-        debug!(
-            "updated intersection_matrix: {:?} from node: {:?}",
-            intersection_matrix, self
-        );
+        debug!("updated intersection_matrix: {intersection_matrix:?} from node: {self:?}");
     }
 }

--- a/geo/src/algorithm/relate/mod.rs
+++ b/geo/src/algorithm/relate/mod.rs
@@ -61,7 +61,7 @@ pub trait Relate<F: GeoFloat>: BoundingRect<F> + HasDimensions {
     ///
     /// `idx`: 0 or 1, designating A or B (respectively) in the role this geometry plays
     ///        in the relation. e.g. in `a.relate(b)`
-    fn geometry_graph(&self, idx: usize) -> GeometryGraph<F>;
+    fn geometry_graph(&self, idx: usize) -> GeometryGraph<'_, F>;
 
     fn relate(&self, other: &impl Relate<F>) -> IntersectionMatrix
     where
@@ -75,7 +75,7 @@ macro_rules! relate_impl {
     ($($t:ty ,)*) => {
         $(
             impl<F: GeoFloat> Relate<F> for $t {
-                fn geometry_graph(&self, arg_index: usize) -> GeometryGraph<F> {
+                fn geometry_graph(&self, arg_index: usize) -> GeometryGraph<'_, F> {
                     $crate::relate::GeometryGraph::new(arg_index, GeometryCow::from(self))
                 }
             }

--- a/geo/src/algorithm/relate/relate_operation.rs
+++ b/geo/src/algorithm/relate/relate_operation.rs
@@ -289,10 +289,7 @@ where
         labeled_node_edges: Vec<(CoordNode<F>, LabeledEdgeEndBundleStar<F>)>,
         intersection_matrix: &mut IntersectionMatrix,
     ) {
-        debug!(
-            "before updated_intersection_matrix(isolated_edges): {:?}",
-            intersection_matrix
-        );
+        debug!("before updated_intersection_matrix(isolated_edges): {intersection_matrix:?}");
         for isolated_edge in &self.isolated_edges {
             let edge = isolated_edge.borrow();
             Edge::<F>::update_intersection_matrix(edge.label(), intersection_matrix);

--- a/geo/src/algorithm/sweep/im_segment.rs
+++ b/geo/src/algorithm/sweep/im_segment.rs
@@ -99,17 +99,13 @@ impl<C: Cross> IMSegment<C> {
     ) -> SplitSegments<C::Scalar> {
         let (adjust_output, new_geom) = {
             let mut segment = RefCell::borrow_mut(&self.inner);
-            trace!(
-                "adjust_for_intersection: {:?}\n\twith: {:?}",
-                segment,
-                adj_intersection
-            );
+            trace!("adjust_for_intersection: {segment:?}\n\twith: {adj_intersection:?}");
             (
                 segment.adjust_for_intersection(adj_intersection),
                 segment.geom,
             )
         };
-        trace!("adjust_output: {:?}", adjust_output);
+        trace!("adjust_output: {adjust_output:?}");
 
         let mut this = self.clone();
         while let Some(ovl) = this.overlap() {

--- a/geo/src/algorithm/sweep/line_or_point.rs
+++ b/geo/src/algorithm/sweep/line_or_point.rs
@@ -305,11 +305,7 @@ impl<T: GeoFloat> LineOrPoint<T> {
                     let l2 = LineOrPoint::from((other.left(), p));
                     let cmp = l1.partial_cmp(&l2).unwrap();
                     if l1.is_line() && l2.is_line() && cmp.then(ord) != ord {
-                        debug!(
-                            "ordering changed by intersection: {l1:?} {ord:?} {l2:?}",
-                            l1 = self,
-                            l2 = other
-                        );
+                        debug!("ordering changed by intersection: {self:?} {ord:?} {other:?}");
                         debug!("\tparts: {l1:?}, {l2:?}");
                         debug!("\tintersection: {p:?} {cmp:?}");
 

--- a/geo/src/algorithm/sweep/proc.rs
+++ b/geo/src/algorithm/sweep/proc.rs
@@ -78,7 +78,7 @@ impl<C: Cross + Clone> Sweep<C> {
             should_callback: false,
         };
         while let Some(isec) = other.geom().intersect_line_ordered(&active.geom()) {
-            trace!("Found intersection (LL):\n\tsegment1: {:?}\n\tsegment2: {:?}\n\tintersection: {:?}", other, active, isec);
+            trace!("Found intersection (LL):\n\tsegment1: {other:?}\n\tsegment2: {active:?}\n\tintersection: {isec:?}");
             out.isec = Some(isec);
 
             // 1. Split adj_segment, and extra splits to storage
@@ -274,7 +274,7 @@ impl<C: Cross + Clone> Sweep<C> {
                         let geom = adj_segment.geom();
                         if let Some(adj_intersection) = segment.geom().intersect_line_ordered(&geom)
                         {
-                            trace!("Found intersection (PL):\n\tsegment1: {:?}\n\tsegment2: {:?}\n\tintersection: {:?}", segment, adj_segment, adj_intersection);
+                            trace!("Found intersection (PL):\n\tsegment1: {segment:?}\n\tsegment2: {adj_segment:?}\n\tintersection: {adj_intersection:?}");
                             // 1. Split adj_segment, and extra splits to storage
                             let adj_overlap = adj_segment
                                 .adjust_one_segment(adj_intersection, |e| self.events.push(e));

--- a/geo/src/algorithm/triangulate_delaunay.rs
+++ b/geo/src/algorithm/triangulate_delaunay.rs
@@ -44,7 +44,7 @@ pub enum TriangulationError {
 
 impl std::fmt::Display for TriangulationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/geo/src/algorithm/triangulate_spade.rs
+++ b/geo/src/algorithm/triangulate_spade.rs
@@ -45,7 +45,7 @@ pub enum TriangulationError {
 
 impl std::fmt::Display for TriangulationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/geo/src/algorithm/validation/geometry.rs
+++ b/geo/src/algorithm/validation/geometry.rs
@@ -28,16 +28,16 @@ pub enum InvalidGeometry {
 impl fmt::Display for InvalidGeometry {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            InvalidGeometry::InvalidPoint(err) => write!(f, "{}", err),
-            InvalidGeometry::InvalidLine(err) => write!(f, "{}", err),
-            InvalidGeometry::InvalidLineString(err) => write!(f, "{}", err),
-            InvalidGeometry::InvalidPolygon(err) => write!(f, "{}", err),
-            InvalidGeometry::InvalidMultiPoint(err) => write!(f, "{}", err),
-            InvalidGeometry::InvalidMultiLineString(err) => write!(f, "{}", err),
-            InvalidGeometry::InvalidMultiPolygon(err) => write!(f, "{}", err),
-            InvalidGeometry::InvalidGeometryCollection(err) => write!(f, "{}", err),
-            InvalidGeometry::InvalidRect(err) => write!(f, "{}", err),
-            InvalidGeometry::InvalidTriangle(err) => write!(f, "{}", err),
+            InvalidGeometry::InvalidPoint(err) => write!(f, "{err}"),
+            InvalidGeometry::InvalidLine(err) => write!(f, "{err}"),
+            InvalidGeometry::InvalidLineString(err) => write!(f, "{err}"),
+            InvalidGeometry::InvalidPolygon(err) => write!(f, "{err}"),
+            InvalidGeometry::InvalidMultiPoint(err) => write!(f, "{err}"),
+            InvalidGeometry::InvalidMultiLineString(err) => write!(f, "{err}"),
+            InvalidGeometry::InvalidMultiPolygon(err) => write!(f, "{err}"),
+            InvalidGeometry::InvalidGeometryCollection(err) => write!(f, "{err}"),
+            InvalidGeometry::InvalidRect(err) => write!(f, "{err}"),
+            InvalidGeometry::InvalidTriangle(err) => write!(f, "{err}"),
         }
     }
 }

--- a/geo/src/algorithm/validation/mod.rs
+++ b/geo/src/algorithm/validation/mod.rs
@@ -111,7 +111,7 @@ impl fmt::Display for RingRole {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             RingRole::Exterior => write!(f, "exterior ring"),
-            RingRole::Interior(idx) => write!(f, "interior ring at index {}", idx),
+            RingRole::Interior(idx) => write!(f, "interior ring at index {idx}"),
         }
     }
 }

--- a/geo/src/algorithm/winding_order.rs
+++ b/geo/src/algorithm/winding_order.rs
@@ -82,13 +82,13 @@ pub trait Winding {
     ///
     /// The object isn't changed, and the points are returned either in order, or in reverse
     /// order, so that the resultant order makes it appear clockwise
-    fn points_cw(&self) -> Points<Self::Scalar>;
+    fn points_cw(&self) -> Points<'_, Self::Scalar>;
 
     /// Iterate over the points in a counter-clockwise order
     ///
     /// The object isn't changed, and the points are returned either in order, or in reverse
     /// order, so that the resultant order makes it appear counter-clockwise
-    fn points_ccw(&self) -> Points<Self::Scalar>;
+    fn points_ccw(&self) -> Points<'_, Self::Scalar>;
 
     /// Change this object's points so they are in clockwise winding order
     fn make_cw_winding(&mut self);
@@ -179,7 +179,7 @@ where
     ///
     /// The Linestring isn't changed, and the points are returned either in order, or in reverse
     /// order, so that the resultant order makes it appear clockwise
-    fn points_cw(&self) -> Points<Self::Scalar> {
+    fn points_cw(&self) -> Points<'_, Self::Scalar> {
         match self.winding_order() {
             Some(WindingOrder::CounterClockwise) => Points(EitherIter::B(self.points().rev())),
             _ => Points(EitherIter::A(self.points())),
@@ -190,7 +190,7 @@ where
     ///
     /// The Linestring isn't changed, and the points are returned either in order, or in reverse
     /// order, so that the resultant order makes it appear counter-clockwise
-    fn points_ccw(&self) -> Points<Self::Scalar> {
+    fn points_ccw(&self) -> Points<'_, Self::Scalar> {
         match self.winding_order() {
             Some(WindingOrder::Clockwise) => Points(EitherIter::B(self.points().rev())),
             _ => Points(EitherIter::A(self.points())),

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -94,7 +94,7 @@
 //!   fraction of a line’s total length representing the location of the closest point on the
 //!   line to the given point
 //! - **[`InteriorPoint`]**:
-//!     Calculates a representative point inside a `Geometry`
+//!   Calculates a representative point inside a `Geometry`
 //!
 //! ## Topology
 //!

--- a/jts-test-runner/src/lib.rs
+++ b/jts-test-runner/src/lib.rs
@@ -25,7 +25,7 @@ pub fn assert_jts_tests_succeed(pattern: &str) {
         let failure_text = runner
             .failures()
             .iter()
-            .map(|failure| format!("{}", failure))
+            .map(|failure| format!("{failure}"))
             .collect::<Vec<String>>()
             .join("\n");
         panic!(

--- a/jts-test-runner/src/runner.rs
+++ b/jts-test-runner/src/runner.rs
@@ -328,7 +328,7 @@ impl TestRunner {
                     match expected {
                         Geometry::MultiPolygon(_) | Geometry::Polygon(_) => {}
                         _ => {
-                            info!("skipping unsupported Union expectation: {:?}", expected);
+                            info!("skipping unsupported Union expectation: {expected:?}");
                             self.unsupported.push(test_case);
                             continue;
                         }
@@ -342,7 +342,7 @@ impl TestRunner {
                         }
                         (Geometry::MultiPolygon(a), Geometry::Polygon(b)) => a.boolean_op(b, *op),
                         _ => {
-                            info!("skipping unsupported Union combination: {:?}, {:?}", a, b);
+                            info!("skipping unsupported Union combination: {a:?}, {b:?}");
                             self.unsupported.push(test_case);
                             continue;
                         }
@@ -376,7 +376,7 @@ impl TestRunner {
                     match expected {
                         Geometry::MultiLineString(_) | Geometry::LineString(_) => {}
                         other => {
-                            info!("skipping unsupported ClipOp output: {:?}", other);
+                            info!("skipping unsupported ClipOp output: {other:?}");
                             self.unsupported.push(test_case);
                             continue;
                         }
@@ -532,7 +532,7 @@ impl TestRunner {
                             }
                         }
                         Err(e) => {
-                            debug!("skipping unsupported operation: {}", e);
+                            debug!("skipping unsupported operation: {e}");
                             continue;
                         }
                     }


### PR DESCRIPTION
This PR continues the work on implementing generic WKB traits for geo algorithms by adding support for the `EuclideanLength` algorithm and addresses various code quality improvements.

  ## Changes

  ### Generic Algorithm Implementation
  - **Transform EuclideanLength to use generic WKB traits**: Converted the deprecated `EuclideanLength` trait implementation in
  `geo-generic-alg/src/algorithm/euclidean_length.rs` to use the generic WKB trait pattern
    - Replaced concrete geometry type implementations (`Line<T>`, `LineString<T>`, `MultiLineString<T>`) with generic trait
  implementations (`LineTraitExt`, `LineStringTraitExt`, `MultiLineStringTraitExt`)
    - Implemented direct Euclidean distance calculations using `delta.x.hypot(delta.y)` instead of delegating to
  `Euclidean.length()`
    - Added proper trait bounds and lifetime management for generic types
    - Maintains the same API while enabling support for any geometry type implementing the appropriate WKB traits

  ## Testing
  - All existing tests pass
  - Cargo build completes without warnings
  - Cargo clippy passes without warnings
  - The transformation maintains backward compatibility while enabling the generic trait pattern

  ## Impact
This change enables the `EuclideanLength` functionality to work with any geometry type that implements the generic WKB traits, making the algorithm more flexible and reusable while maintaining the existing API surface.