### PR TITLE
Export LengthMeasurableExt in  algorithm/mod.rs

### DIFF
--- a/geo-generic-alg/src/algorithm/mod.rs
+++ b/geo-generic-alg/src/algorithm/mod.rs
@@ -195,7 +195,7 @@ pub use line_measures::metric_spaces::{
 };
 pub use line_measures::{
     Bearing, Densify, Destination, Distance, InterpolatableLine, InterpolateLine, InterpolatePoint,
-    Length,
+    Length, LengthMeasurable, LengthMeasurableExt,
 };
 
 /// Split a LineString into n segments


### PR DESCRIPTION
This pr exports LengthMeasurableExt in  algorithm/mod.rs so that external library can use it.