### PR TITLE
Redesign GeometryTraitExt to eliminate GAT recursion to work around a Rust compiler bug in 1.90.0

### DIFF
--- a/geo-generic-alg/src/algorithm/area.rs
+++ b/geo-generic-alg/src/algorithm/area.rs
@@ -1,6 +1,7 @@
 use geo_traits_ext::*;
 
 use crate::{CoordFloat, CoordNum};
+use core::borrow::Borrow;
 
 pub(crate) fn twice_signed_ring_area<T: CoordNum, LS: LineStringTraitExt<T = T>>(
     linestring: &LS,
@@ -260,16 +261,6 @@ where
     }
 }
 
-impl<T, G: GeometryTraitExt<T = T>> AreaTrait<T, GeometryTag> for G
-where
-    T: CoordFloat,
-{
-    crate::geometry_trait_ext_delegate_impl! {
-        fn signed_area_trait(&self) -> T;
-        fn unsigned_area_trait(&self) -> T;
-    }
-}
-
 impl<T, GC: GeometryCollectionTraitExt<T = T>> AreaTrait<T, GeometryCollectionTag> for GC
 where
     T: CoordFloat,
@@ -284,6 +275,51 @@ where
         self.geometries_ext()
             .map(|g| g.unsigned_area_trait())
             .fold(T::zero(), |acc, next| acc + next)
+    }
+}
+
+impl<T, G: GeometryTraitExt<T = T>> AreaTrait<T, GeometryTag> for G
+where
+    T: CoordFloat,
+{
+    fn signed_area_trait(&self) -> T {
+        if self.is_collection() {
+            self.geometries_ext()
+                .map(|g_inner| g_inner.borrow().signed_area_trait())
+                .fold(T::zero(), |acc, next| acc + next)
+        } else {
+            match self.as_type_ext() {
+                GeometryTypeExt::Point(g) => g.signed_area_trait(),
+                GeometryTypeExt::Line(g) => g.signed_area_trait(),
+                GeometryTypeExt::LineString(g) => g.signed_area_trait(),
+                GeometryTypeExt::Polygon(g) => g.signed_area_trait(),
+                GeometryTypeExt::MultiPoint(g) => g.signed_area_trait(),
+                GeometryTypeExt::MultiLineString(g) => g.signed_area_trait(),
+                GeometryTypeExt::MultiPolygon(g) => g.signed_area_trait(),
+                GeometryTypeExt::Rect(g) => g.signed_area_trait(),
+                GeometryTypeExt::Triangle(g) => g.signed_area_trait(),
+            }
+        }
+    }
+
+    fn unsigned_area_trait(&self) -> T {
+        if self.is_collection() {
+            self.geometries_ext()
+                .map(|g_inner| g_inner.borrow().unsigned_area_trait())
+                .fold(T::zero(), |acc, next| acc + next)
+        } else {
+            match self.as_type_ext() {
+                GeometryTypeExt::Point(g) => g.unsigned_area_trait(),
+                GeometryTypeExt::Line(g) => g.unsigned_area_trait(),
+                GeometryTypeExt::LineString(g) => g.unsigned_area_trait(),
+                GeometryTypeExt::Polygon(g) => g.unsigned_area_trait(),
+                GeometryTypeExt::MultiPoint(g) => g.unsigned_area_trait(),
+                GeometryTypeExt::MultiLineString(g) => g.unsigned_area_trait(),
+                GeometryTypeExt::MultiPolygon(g) => g.unsigned_area_trait(),
+                GeometryTypeExt::Rect(g) => g.unsigned_area_trait(),
+                GeometryTypeExt::Triangle(g) => g.unsigned_area_trait(),
+            }
+        }
     }
 }
 

--- a/geo-generic-alg/src/algorithm/bounding_rect.rs
+++ b/geo-generic-alg/src/algorithm/bounding_rect.rs
@@ -240,11 +240,11 @@ where
             match self.as_type_ext() {
                 GeometryTypeExt::Point(g) => g.bounding_rect_trait().into(),
                 GeometryTypeExt::Line(g) => g.bounding_rect_trait().into(),
-                GeometryTypeExt::LineString(g) => g.bounding_rect_trait().into(),
-                GeometryTypeExt::Polygon(g) => g.bounding_rect_trait().into(),
-                GeometryTypeExt::MultiPoint(g) => g.bounding_rect_trait().into(),
-                GeometryTypeExt::MultiLineString(g) => g.bounding_rect_trait().into(),
-                GeometryTypeExt::MultiPolygon(g) => g.bounding_rect_trait().into(),
+                GeometryTypeExt::LineString(g) => g.bounding_rect_trait(),
+                GeometryTypeExt::Polygon(g) => g.bounding_rect_trait(),
+                GeometryTypeExt::MultiPoint(g) => g.bounding_rect_trait(),
+                GeometryTypeExt::MultiLineString(g) => g.bounding_rect_trait(),
+                GeometryTypeExt::MultiPolygon(g) => g.bounding_rect_trait(),
                 GeometryTypeExt::Rect(g) => g.bounding_rect_trait().into(),
                 GeometryTypeExt::Triangle(g) => g.bounding_rect_trait().into(),
             }

--- a/geo-generic-alg/src/algorithm/bounding_rect.rs
+++ b/geo-generic-alg/src/algorithm/bounding_rect.rs
@@ -1,8 +1,8 @@
 use crate::utils::{partial_max, partial_min};
 use crate::{coord, geometry::*, CoordNum, GeometryCow};
+use core::borrow::Borrow;
 use geo_traits_ext::*;
 use geo_types::private_utils::get_bounding_rect;
-use core::borrow::Borrow;
 
 /// Calculation of the bounding rectangle of a geometry.
 pub trait BoundingRect<T: CoordNum> {

--- a/geo-generic-alg/src/algorithm/bounding_rect.rs
+++ b/geo-generic-alg/src/algorithm/bounding_rect.rs
@@ -2,6 +2,7 @@ use crate::utils::{partial_max, partial_min};
 use crate::{coord, geometry::*, CoordNum, GeometryCow};
 use geo_traits_ext::*;
 use geo_types::private_utils::get_bounding_rect;
+use core::borrow::Borrow;
 
 /// Calculation of the bounding rectangle of a geometry.
 pub trait BoundingRect<T: CoordNum> {
@@ -199,17 +200,6 @@ where
     }
 }
 
-impl<T, G: GeometryTraitExt<T = T>> BoundingRectTrait<T, GeometryTag> for G
-where
-    T: CoordNum,
-{
-    type Output = Option<Rect<T>>;
-
-    crate::geometry_trait_ext_delegate_impl! {
-       fn bounding_rect_trait(&self) -> Self::Output;
-    }
-}
-
 impl<T, GC: GeometryCollectionTraitExt<T = T>> BoundingRectTrait<T, GeometryCollectionTag> for GC
 where
     T: CoordNum,
@@ -226,6 +216,39 @@ where
                 (Some(r1), Some(r2)) => Some(bounding_rect_merge(r1, r2)),
             }
         })
+    }
+}
+
+impl<T, G: GeometryTraitExt<T = T>> BoundingRectTrait<T, GeometryTag> for G
+where
+    T: CoordNum,
+{
+    type Output = Option<Rect<T>>;
+
+    fn bounding_rect_trait(&self) -> Self::Output {
+        if self.is_collection() {
+            self.geometries_ext().fold(None, |acc, next| {
+                let next_bounding_rect = next.borrow().bounding_rect_trait();
+
+                match (acc, next_bounding_rect) {
+                    (None, None) => None,
+                    (Some(r), None) | (None, Some(r)) => Some(r),
+                    (Some(r1), Some(r2)) => Some(bounding_rect_merge(r1, r2)),
+                }
+            })
+        } else {
+            match self.as_type_ext() {
+                GeometryTypeExt::Point(g) => g.bounding_rect_trait().into(),
+                GeometryTypeExt::Line(g) => g.bounding_rect_trait().into(),
+                GeometryTypeExt::LineString(g) => g.bounding_rect_trait().into(),
+                GeometryTypeExt::Polygon(g) => g.bounding_rect_trait().into(),
+                GeometryTypeExt::MultiPoint(g) => g.bounding_rect_trait().into(),
+                GeometryTypeExt::MultiLineString(g) => g.bounding_rect_trait().into(),
+                GeometryTypeExt::MultiPolygon(g) => g.bounding_rect_trait().into(),
+                GeometryTypeExt::Rect(g) => g.bounding_rect_trait().into(),
+                GeometryTypeExt::Triangle(g) => g.bounding_rect_trait().into(),
+            }
+        }
     }
 }
 

--- a/geo-generic-alg/src/algorithm/bounding_rect.rs
+++ b/geo-generic-alg/src/algorithm/bounding_rect.rs
@@ -402,5 +402,13 @@ mod test {
             ])
             .bounding_rect(),
         );
+        assert_eq!(
+            Some(Rect::new(coord! { x: 0., y: 0. }, coord! { x: 1., y: 2. })),
+            Geometry::GeometryCollection(GeometryCollection::new_from(vec![
+                Geometry::Point(point! { x: 0., y: 0. }),
+                Geometry::Point(point! { x: 1., y: 2. }),
+            ]))
+            .bounding_rect(),
+        );
     }
 }

--- a/geo-generic-alg/src/algorithm/centroid.rs
+++ b/geo-generic-alg/src/algorithm/centroid.rs
@@ -1,5 +1,5 @@
-use std::cmp::Ordering;
 use core::borrow::Borrow;
+use std::cmp::Ordering;
 
 use geo_traits_ext::*;
 

--- a/geo-generic-alg/src/algorithm/centroid.rs
+++ b/geo-generic-alg/src/algorithm/centroid.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use core::borrow::Borrow;
 
 use geo_traits_ext::*;
 
@@ -383,6 +384,33 @@ where
     }
 }
 
+fn geometry_centroid<T, G>(g: &G) -> Option<Point<T>>
+where
+    T: GeoFloat,
+    G: GeometryTraitExt<T = T>,
+{
+    if g.is_collection() {
+        // Handle geometry collection by computing weighted centroid
+        let mut operation = CentroidOperation::new();
+        for g_inner in g.geometries_ext() {
+            operation.add_geometry(g_inner.borrow());
+        }
+        operation.centroid()
+    } else {
+        match g.as_type_ext() {
+            GeometryTypeExt::Point(g) => Some(g.centroid_trait()),
+            GeometryTypeExt::Line(g) => Some(g.centroid_trait()),
+            GeometryTypeExt::LineString(g) => g.centroid_trait(),
+            GeometryTypeExt::Polygon(g) => g.centroid_trait(),
+            GeometryTypeExt::MultiPoint(g) => g.centroid_trait(),
+            GeometryTypeExt::MultiLineString(g) => g.centroid_trait(),
+            GeometryTypeExt::MultiPolygon(g) => g.centroid_trait(),
+            GeometryTypeExt::Rect(g) => Some(g.centroid_trait()),
+            GeometryTypeExt::Triangle(g) => Some(g.centroid_trait()),
+        }
+    }
+}
+
 impl<T, G> CentroidTrait<GeometryTag> for G
 where
     T: GeoFloat,
@@ -390,32 +418,32 @@ where
 {
     type Output = Option<Point<T>>;
 
-    crate::geometry_trait_ext_delegate_impl! {
-        /// The Centroid of a [`Geometry`] is the centroid of its enum variant
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use geo::Centroid;
-        /// use geo::{Geometry, Rect, point};
-        ///
-        /// let rect = Rect::new(
-        ///   point!(x: 0.0f32, y: 0.0),
-        ///   point!(x: 1.0, y: 1.0),
-        /// );
-        /// let geometry = Geometry::from(rect.clone());
-        ///
-        /// assert_eq!(
-        ///     Some(rect.centroid()),
-        ///     geometry.centroid(),
-        /// );
-        ///
-        /// assert_eq!(
-        ///     Some(point!(x: 0.5, y: 0.5)),
-        ///     geometry.centroid(),
-        /// );
-        /// ```
-        fn centroid_trait(&self) -> Self::Output;
+    /// The Centroid of a [`Geometry`] is the centroid of its enum variant
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo::Centroid;
+    /// use geo::{Geometry, Rect, point};
+    ///
+    /// let rect = Rect::new(
+    ///   point!(x: 0.0f32, y: 0.0),
+    ///   point!(x: 1.0, y: 1.0),
+    /// );
+    /// let geometry = Geometry::from(rect.clone());
+    ///
+    /// assert_eq!(
+    ///     Some(rect.centroid()),
+    ///     geometry.centroid(),
+    /// );
+    ///
+    /// assert_eq!(
+    ///     Some(point!(x: 0.5, y: 0.5)),
+    ///     geometry.centroid(),
+    /// );
+    /// ```
+    fn centroid_trait(&self) -> Self::Output {
+        geometry_centroid(self)
     }
 }
 
@@ -658,21 +686,26 @@ impl<T: GeoFloat> CentroidOperation<T> {
     where
         G: GeometryTraitExt<T = T>,
     {
-        match geometry.as_type_ext() {
-            GeometryTypeExt::Point(g) => {
-                if let Some(coord) = g.geo_coord() {
-                    self.add_coord(coord)
-                }
+        if geometry.is_collection() {
+            for g_inner in geometry.geometries_ext() {
+                self.add_geometry(g_inner.borrow());
             }
-            GeometryTypeExt::Line(g) => self.add_line(g),
-            GeometryTypeExt::LineString(g) => self.add_line_string(g),
-            GeometryTypeExt::Polygon(g) => self.add_polygon(g),
-            GeometryTypeExt::MultiPoint(g) => self.add_multi_point(g),
-            GeometryTypeExt::MultiLineString(g) => self.add_multi_line_string(g),
-            GeometryTypeExt::MultiPolygon(g) => self.add_multi_polygon(g),
-            // GeometryTypeExt::GeometryCollection(g) => self.add_geometry_collection(g),
-            GeometryTypeExt::Rect(g) => self.add_rect(g),
-            GeometryTypeExt::Triangle(g) => self.add_triangle(g),
+        } else {
+            match geometry.as_type_ext() {
+                GeometryTypeExt::Point(g) => {
+                    if let Some(coord) = g.geo_coord() {
+                        self.add_coord(coord)
+                    }
+                }
+                GeometryTypeExt::Line(g) => self.add_line(g),
+                GeometryTypeExt::LineString(g) => self.add_line_string(g),
+                GeometryTypeExt::Polygon(g) => self.add_polygon(g),
+                GeometryTypeExt::MultiPoint(g) => self.add_multi_point(g),
+                GeometryTypeExt::MultiLineString(g) => self.add_multi_line_string(g),
+                GeometryTypeExt::MultiPolygon(g) => self.add_multi_polygon(g),
+                GeometryTypeExt::Rect(g) => self.add_rect(g),
+                GeometryTypeExt::Triangle(g) => self.add_triangle(g),
+            }
         }
     }
 

--- a/geo-generic-alg/src/algorithm/centroid.rs
+++ b/geo-generic-alg/src/algorithm/centroid.rs
@@ -384,33 +384,6 @@ where
     }
 }
 
-fn geometry_centroid<T, G>(g: &G) -> Option<Point<T>>
-where
-    T: GeoFloat,
-    G: GeometryTraitExt<T = T>,
-{
-    if g.is_collection() {
-        // Handle geometry collection by computing weighted centroid
-        let mut operation = CentroidOperation::new();
-        for g_inner in g.geometries_ext() {
-            operation.add_geometry(g_inner.borrow());
-        }
-        operation.centroid()
-    } else {
-        match g.as_type_ext() {
-            GeometryTypeExt::Point(g) => Some(g.centroid_trait()),
-            GeometryTypeExt::Line(g) => Some(g.centroid_trait()),
-            GeometryTypeExt::LineString(g) => g.centroid_trait(),
-            GeometryTypeExt::Polygon(g) => g.centroid_trait(),
-            GeometryTypeExt::MultiPoint(g) => g.centroid_trait(),
-            GeometryTypeExt::MultiLineString(g) => g.centroid_trait(),
-            GeometryTypeExt::MultiPolygon(g) => g.centroid_trait(),
-            GeometryTypeExt::Rect(g) => Some(g.centroid_trait()),
-            GeometryTypeExt::Triangle(g) => Some(g.centroid_trait()),
-        }
-    }
-}
-
 impl<T, G> CentroidTrait<GeometryTag> for G
 where
     T: GeoFloat,
@@ -443,7 +416,26 @@ where
     /// );
     /// ```
     fn centroid_trait(&self) -> Self::Output {
-        geometry_centroid(self)
+        if self.is_collection() {
+            // Handle geometry collection by computing weighted centroid
+            let mut operation = CentroidOperation::new();
+            for g_inner in self.geometries_ext() {
+                operation.add_geometry(g_inner.borrow());
+            }
+            operation.centroid()
+        } else {
+            match self.as_type_ext() {
+                GeometryTypeExt::Point(g) => Some(g.centroid_trait()),
+                GeometryTypeExt::Line(g) => Some(g.centroid_trait()),
+                GeometryTypeExt::LineString(g) => g.centroid_trait(),
+                GeometryTypeExt::Polygon(g) => g.centroid_trait(),
+                GeometryTypeExt::MultiPoint(g) => g.centroid_trait(),
+                GeometryTypeExt::MultiLineString(g) => g.centroid_trait(),
+                GeometryTypeExt::MultiPolygon(g) => g.centroid_trait(),
+                GeometryTypeExt::Rect(g) => Some(g.centroid_trait()),
+                GeometryTypeExt::Triangle(g) => Some(g.centroid_trait()),
+            }
+        }
     }
 }
 

--- a/geo-generic-alg/src/algorithm/centroid.rs
+++ b/geo-generic-alg/src/algorithm/centroid.rs
@@ -670,7 +670,7 @@ impl<T: GeoFloat> CentroidOperation<T> {
             GeometryTypeExt::MultiPoint(g) => self.add_multi_point(g),
             GeometryTypeExt::MultiLineString(g) => self.add_multi_line_string(g),
             GeometryTypeExt::MultiPolygon(g) => self.add_multi_polygon(g),
-            GeometryTypeExt::GeometryCollection(g) => self.add_geometry_collection(g),
+            // GeometryTypeExt::GeometryCollection(g) => self.add_geometry_collection(g),
             GeometryTypeExt::Rect(g) => self.add_rect(g),
             GeometryTypeExt::Triangle(g) => self.add_triangle(g),
         }

--- a/geo-generic-alg/src/algorithm/coordinate_position.rs
+++ b/geo-generic-alg/src/algorithm/coordinate_position.rs
@@ -824,10 +824,15 @@ mod test {
         let triangle = Triangle::new((0.0, 0.0).into(), (5.0, 10.0).into(), (10.0, 0.0).into());
         let rect = Rect::new((0.0, 0.0), (10.0, 10.0));
         let collection = GeometryCollection::new_from(vec![triangle.into(), rect.into()]);
+        let geom = Geometry::GeometryCollection(collection.clone());
 
         //  outside of both
         assert_eq!(
             collection.coordinate_position(&coord! { x: 15.0, y: 15.0 }),
+            CoordPos::Outside
+        );
+        assert_eq!(
+            geom.coordinate_position(&coord! { x: 15.0, y: 15.0 }),
             CoordPos::Outside
         );
 
@@ -836,16 +841,28 @@ mod test {
             collection.coordinate_position(&coord! { x: 5.0, y: 5.0 }),
             CoordPos::Inside
         );
+        assert_eq!(
+            geom.coordinate_position(&coord! { x: 5.0, y: 5.0 }),
+            CoordPos::Inside
+        );
 
         // inside one, boundary of other
         assert_eq!(
             collection.coordinate_position(&coord! { x: 2.5, y: 5.0 }),
             CoordPos::OnBoundary
         );
+        assert_eq!(
+            geom.coordinate_position(&coord! { x: 2.5, y: 5.0 }),
+            CoordPos::OnBoundary
+        );
 
         //  boundary of both
         assert_eq!(
             collection.coordinate_position(&coord! { x: 5.0, y: 10.0 }),
+            CoordPos::Outside
+        );
+        assert_eq!(
+            geom.coordinate_position(&coord! { x: 5.0, y: 10.0 }),
             CoordPos::Outside
         );
     }

--- a/geo-generic-alg/src/algorithm/coordinate_position.rs
+++ b/geo-generic-alg/src/algorithm/coordinate_position.rs
@@ -1,5 +1,5 @@
-use std::cmp::Ordering;
 use core::borrow::Borrow;
+use std::cmp::Ordering;
 
 use crate::geometry::*;
 use crate::intersects::{point_in_rect, value_in_between};
@@ -441,19 +441,42 @@ fn geometry_calculate_coordinate_position<T, G>(
 {
     if g.is_collection() {
         for g_inner in g.geometries_ext() {
-            geometry_calculate_coordinate_position(g_inner.borrow(), coord, is_inside, boundary_count);
+            geometry_calculate_coordinate_position(
+                g_inner.borrow(),
+                coord,
+                is_inside,
+                boundary_count,
+            );
         }
     } else {
         match g.as_type_ext() {
-            GeometryTypeExt::Point(g) => g.calculate_coordinate_position_trait(coord, is_inside, boundary_count),
-            GeometryTypeExt::Line(g) => g.calculate_coordinate_position_trait(coord, is_inside, boundary_count),
-            GeometryTypeExt::LineString(g) => g.calculate_coordinate_position_trait(coord, is_inside, boundary_count),
-            GeometryTypeExt::Polygon(g) => g.calculate_coordinate_position_trait(coord, is_inside, boundary_count),
-            GeometryTypeExt::MultiPoint(g) => g.calculate_coordinate_position_trait(coord, is_inside, boundary_count),
-            GeometryTypeExt::MultiLineString(g) => g.calculate_coordinate_position_trait(coord, is_inside, boundary_count),
-            GeometryTypeExt::MultiPolygon(g) => g.calculate_coordinate_position_trait(coord, is_inside, boundary_count),
-            GeometryTypeExt::Rect(g) => g.calculate_coordinate_position_trait(coord, is_inside, boundary_count),
-            GeometryTypeExt::Triangle(g) => g.calculate_coordinate_position_trait(coord, is_inside, boundary_count),
+            GeometryTypeExt::Point(g) => {
+                g.calculate_coordinate_position_trait(coord, is_inside, boundary_count)
+            }
+            GeometryTypeExt::Line(g) => {
+                g.calculate_coordinate_position_trait(coord, is_inside, boundary_count)
+            }
+            GeometryTypeExt::LineString(g) => {
+                g.calculate_coordinate_position_trait(coord, is_inside, boundary_count)
+            }
+            GeometryTypeExt::Polygon(g) => {
+                g.calculate_coordinate_position_trait(coord, is_inside, boundary_count)
+            }
+            GeometryTypeExt::MultiPoint(g) => {
+                g.calculate_coordinate_position_trait(coord, is_inside, boundary_count)
+            }
+            GeometryTypeExt::MultiLineString(g) => {
+                g.calculate_coordinate_position_trait(coord, is_inside, boundary_count)
+            }
+            GeometryTypeExt::MultiPolygon(g) => {
+                g.calculate_coordinate_position_trait(coord, is_inside, boundary_count)
+            }
+            GeometryTypeExt::Rect(g) => {
+                g.calculate_coordinate_position_trait(coord, is_inside, boundary_count)
+            }
+            GeometryTypeExt::Triangle(g) => {
+                g.calculate_coordinate_position_trait(coord, is_inside, boundary_count)
+            }
         }
     }
 }

--- a/geo-generic-alg/src/algorithm/coordinate_position.rs
+++ b/geo-generic-alg/src/algorithm/coordinate_position.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use core::borrow::Borrow;
 
 use crate::geometry::*;
 use crate::intersects::{point_in_rect, value_in_between};
@@ -429,6 +430,34 @@ where
     }
 }
 
+fn geometry_calculate_coordinate_position<T, G>(
+    g: &G,
+    coord: &Coord<T>,
+    is_inside: &mut bool,
+    boundary_count: &mut usize,
+) where
+    T: GeoNum,
+    G: GeometryTraitExt<T = T>,
+{
+    if g.is_collection() {
+        for g_inner in g.geometries_ext() {
+            geometry_calculate_coordinate_position(g_inner.borrow(), coord, is_inside, boundary_count);
+        }
+    } else {
+        match g.as_type_ext() {
+            GeometryTypeExt::Point(g) => g.calculate_coordinate_position_trait(coord, is_inside, boundary_count),
+            GeometryTypeExt::Line(g) => g.calculate_coordinate_position_trait(coord, is_inside, boundary_count),
+            GeometryTypeExt::LineString(g) => g.calculate_coordinate_position_trait(coord, is_inside, boundary_count),
+            GeometryTypeExt::Polygon(g) => g.calculate_coordinate_position_trait(coord, is_inside, boundary_count),
+            GeometryTypeExt::MultiPoint(g) => g.calculate_coordinate_position_trait(coord, is_inside, boundary_count),
+            GeometryTypeExt::MultiLineString(g) => g.calculate_coordinate_position_trait(coord, is_inside, boundary_count),
+            GeometryTypeExt::MultiPolygon(g) => g.calculate_coordinate_position_trait(coord, is_inside, boundary_count),
+            GeometryTypeExt::Rect(g) => g.calculate_coordinate_position_trait(coord, is_inside, boundary_count),
+            GeometryTypeExt::Triangle(g) => g.calculate_coordinate_position_trait(coord, is_inside, boundary_count),
+        }
+    }
+}
+
 impl<T, G> CoordinatePositionTrait<GeometryTag> for G
 where
     T: GeoNum,
@@ -436,12 +465,13 @@ where
 {
     type T = T;
 
-    crate::geometry_trait_ext_delegate_impl! {
-        fn calculate_coordinate_position_trait(
-            &self,
-            coord: &Coord<T>,
-            is_inside: &mut bool,
-            boundary_count: &mut usize) -> ();
+    fn calculate_coordinate_position_trait(
+        &self,
+        coord: &Coord<T>,
+        is_inside: &mut bool,
+        boundary_count: &mut usize,
+    ) {
+        geometry_calculate_coordinate_position(self, coord, is_inside, boundary_count);
     }
 }
 

--- a/geo-generic-alg/src/algorithm/coords_iter.rs
+++ b/geo-generic-alg/src/algorithm/coords_iter.rs
@@ -983,30 +983,6 @@ where
     }
 }
 
-fn geometry_coords_count<T, G>(g: &G) -> usize
-where
-    T: CoordNum,
-    G: GeometryTraitExt<T = T>,
-{
-    if g.is_collection() {
-        g.geometries_ext()
-            .map(|g_inner| geometry_coords_count(g_inner.borrow()))
-            .sum()
-    } else {
-        match g.as_type_ext() {
-            GeometryTypeExt::Point(g) => g.coords_count_trait(),
-            GeometryTypeExt::Line(g) => g.coords_count_trait(),
-            GeometryTypeExt::LineString(g) => g.coords_count_trait(),
-            GeometryTypeExt::Polygon(g) => g.coords_count_trait(),
-            GeometryTypeExt::MultiPoint(g) => g.coords_count_trait(),
-            GeometryTypeExt::MultiLineString(g) => g.coords_count_trait(),
-            GeometryTypeExt::MultiPolygon(g) => g.coords_count_trait(),
-            GeometryTypeExt::Rect(g) => g.coords_count_trait(),
-            GeometryTypeExt::Triangle(g) => g.coords_count_trait(),
-        }
-    }
-}
-
 // ┌─────────────────────────────┐
 // │ Implementation for Geometry │
 // └─────────────────────────────┘
@@ -1064,7 +1040,23 @@ where
 
     /// Return the number of coordinates in the `Geometry`.
     fn coords_count_trait(&self) -> usize {
-        geometry_coords_count(self)
+        if self.is_collection() {
+            self.geometries_ext()
+                .map(|g_inner| g_inner.borrow().coords_count_trait())
+                .sum()
+        } else {
+            match self.as_type_ext() {
+                GeometryTypeExt::Point(g) => g.coords_count_trait(),
+                GeometryTypeExt::Line(g) => g.coords_count_trait(),
+                GeometryTypeExt::LineString(g) => g.coords_count_trait(),
+                GeometryTypeExt::Polygon(g) => g.coords_count_trait(),
+                GeometryTypeExt::MultiPoint(g) => g.coords_count_trait(),
+                GeometryTypeExt::MultiLineString(g) => g.coords_count_trait(),
+                GeometryTypeExt::MultiPolygon(g) => g.coords_count_trait(),
+                GeometryTypeExt::Rect(g) => g.coords_count_trait(),
+                GeometryTypeExt::Triangle(g) => g.coords_count_trait(),
+            }
+        }
     }
 
     fn exterior_coords_iter_trait(&self) -> Self::ExteriorIter<'_> {
@@ -1262,11 +1254,6 @@ where
     MultiPolygon(
         <G::MultiPolygonTypeExt<'a> as CoordsIterTrait<MultiPolygonTag>>::ExteriorIter<'a>,
     ),
-    // GeometryCollection(
-    //     <G::GeometryCollectionTypeExt<'a> as CoordsIterTrait<GeometryCollectionTag>>::ExteriorIter<
-    //         'a,
-    //     >,
-    // ),
     GeometryCollection(
         std::vec::IntoIter<Coord<G::T>>,
     ),
@@ -1438,13 +1425,16 @@ mod test {
         let (polygon, mut coords) = create_polygon();
         expected_coords.append(&mut coords);
 
-        let actual_coords = GeometryCollection::new_from(vec![
+        let collection = GeometryCollection::new_from(vec![
             Geometry::LineString(line_string),
             Geometry::Polygon(polygon),
-        ])
-        .coords_iter()
-        .collect::<Vec<_>>();
+        ]);
+        let geom = Geometry::GeometryCollection(collection.clone());
 
+        let actual_coords = collection.coords_iter().collect::<Vec<_>>();
+        assert_eq!(expected_coords, actual_coords);
+
+        let actual_coords = geom.coords_iter().collect::<Vec<_>>();
         assert_eq!(expected_coords, actual_coords);
     }
 

--- a/geo-generic-alg/src/algorithm/coords_iter.rs
+++ b/geo-generic-alg/src/algorithm/coords_iter.rs
@@ -1019,9 +1019,9 @@ where
             GeometryTypeExt::MultiPolygon(g) => {
                 GeometryTraitCoordsIter::MultiPolygon(g.coords_iter_trait())
             }
-            GeometryTypeExt::GeometryCollection(g) => {
-                GeometryTraitCoordsIter::GeometryCollection(g.coords_iter_trait())
-            }
+            // GeometryTypeExt::GeometryCollection(g) => {
+            //     GeometryTraitCoordsIter::GeometryCollection(g.coords_iter_trait())
+            // }
             GeometryTypeExt::Rect(g) => GeometryTraitCoordsIter::Rect(g.coords_iter_trait()),
             GeometryTypeExt::Triangle(g) => {
                 GeometryTraitCoordsIter::Triangle(g.coords_iter_trait())
@@ -1057,9 +1057,9 @@ where
             GeometryTypeExt::MultiPolygon(g) => {
                 GeometryTraitExteriorCoordsIter::MultiPolygon(g.exterior_coords_iter_trait())
             }
-            GeometryTypeExt::GeometryCollection(g) => {
-                GeometryTraitExteriorCoordsIter::GeometryCollection(g.exterior_coords_iter_trait())
-            }
+            // GeometryTypeExt::GeometryCollection(g) => {
+            //     GeometryTraitExteriorCoordsIter::GeometryCollection(g.exterior_coords_iter_trait())
+            // }
             GeometryTypeExt::Rect(g) => {
                 GeometryTraitExteriorCoordsIter::Rect(g.exterior_coords_iter_trait())
             }
@@ -1162,9 +1162,9 @@ where
         <G::MultiLineStringTypeExt<'a> as CoordsIterTrait<MultiLineStringTag>>::Iter<'a>,
     ),
     MultiPolygon(<G::MultiPolygonTypeExt<'a> as CoordsIterTrait<MultiPolygonTag>>::Iter<'a>),
-    GeometryCollection(
-        <G::GeometryCollectionTypeExt<'a> as CoordsIterTrait<GeometryCollectionTag>>::Iter<'a>,
-    ),
+    // GeometryCollection(
+    //     <G::GeometryCollectionTypeExt<'a> as CoordsIterTrait<GeometryCollectionTag>>::Iter<'a>,
+    // ),
     Rect(<G::RectTypeExt<'a> as CoordsIterTrait<RectTag>>::Iter<'a>),
     Triangle(<G::TriangleTypeExt<'a> as CoordsIterTrait<TriangleTag>>::Iter<'a>),
 }
@@ -1184,7 +1184,7 @@ where
             GeometryTraitCoordsIter::MultiPoint(g) => g.next(),
             GeometryTraitCoordsIter::MultiLineString(g) => g.next(),
             GeometryTraitCoordsIter::MultiPolygon(g) => g.next(),
-            GeometryTraitCoordsIter::GeometryCollection(g) => g.next(),
+            // GeometryTraitCoordsIter::GeometryCollection(g) => g.next(),
             GeometryTraitCoordsIter::Rect(g) => g.next(),
             GeometryTraitCoordsIter::Triangle(g) => g.next(),
         }
@@ -1199,7 +1199,7 @@ where
             GeometryTraitCoordsIter::MultiPoint(g) => g.size_hint(),
             GeometryTraitCoordsIter::MultiLineString(g) => g.size_hint(),
             GeometryTraitCoordsIter::MultiPolygon(g) => g.size_hint(),
-            GeometryTraitCoordsIter::GeometryCollection(g) => g.size_hint(),
+            // GeometryTraitCoordsIter::GeometryCollection(g) => g.size_hint(),
             GeometryTraitCoordsIter::Rect(g) => g.size_hint(),
             GeometryTraitCoordsIter::Triangle(g) => g.size_hint(),
         }
@@ -1223,11 +1223,11 @@ where
     MultiPolygon(
         <G::MultiPolygonTypeExt<'a> as CoordsIterTrait<MultiPolygonTag>>::ExteriorIter<'a>,
     ),
-    GeometryCollection(
-        <G::GeometryCollectionTypeExt<'a> as CoordsIterTrait<GeometryCollectionTag>>::ExteriorIter<
-            'a,
-        >,
-    ),
+    // GeometryCollection(
+    //     <G::GeometryCollectionTypeExt<'a> as CoordsIterTrait<GeometryCollectionTag>>::ExteriorIter<
+    //         'a,
+    //     >,
+    // ),
     Rect(<G::RectTypeExt<'a> as CoordsIterTrait<RectTag>>::ExteriorIter<'a>),
     Triangle(<G::TriangleTypeExt<'a> as CoordsIterTrait<TriangleTag>>::ExteriorIter<'a>),
 }
@@ -1247,7 +1247,7 @@ where
             GeometryTraitExteriorCoordsIter::MultiPoint(g) => g.next(),
             GeometryTraitExteriorCoordsIter::MultiLineString(g) => g.next(),
             GeometryTraitExteriorCoordsIter::MultiPolygon(g) => g.next(),
-            GeometryTraitExteriorCoordsIter::GeometryCollection(g) => g.next(),
+            // GeometryTraitExteriorCoordsIter::GeometryCollection(g) => g.next(),
             GeometryTraitExteriorCoordsIter::Rect(g) => g.next(),
             GeometryTraitExteriorCoordsIter::Triangle(g) => g.next(),
         }
@@ -1262,7 +1262,7 @@ where
             GeometryTraitExteriorCoordsIter::MultiPoint(g) => g.size_hint(),
             GeometryTraitExteriorCoordsIter::MultiLineString(g) => g.size_hint(),
             GeometryTraitExteriorCoordsIter::MultiPolygon(g) => g.size_hint(),
-            GeometryTraitExteriorCoordsIter::GeometryCollection(g) => g.size_hint(),
+            // GeometryTraitExteriorCoordsIter::GeometryCollection(g) => g.size_hint(),
             GeometryTraitExteriorCoordsIter::Rect(g) => g.size_hint(),
             GeometryTraitExteriorCoordsIter::Triangle(g) => g.size_hint(),
         }

--- a/geo-generic-alg/src/algorithm/coords_iter.rs
+++ b/geo-generic-alg/src/algorithm/coords_iter.rs
@@ -1020,7 +1020,9 @@ where
                 GeometryTypeExt::LineString(g) => {
                     GeometryTraitCoordsIter::LineString(g.coords_iter_trait())
                 }
-                GeometryTypeExt::Polygon(g) => GeometryTraitCoordsIter::Polygon(g.coords_iter_trait()),
+                GeometryTypeExt::Polygon(g) => {
+                    GeometryTraitCoordsIter::Polygon(g.coords_iter_trait())
+                }
                 GeometryTypeExt::MultiPoint(g) => {
                     GeometryTraitCoordsIter::MultiPoint(g.coords_iter_trait())
                 }
@@ -1193,9 +1195,7 @@ where
         <G::MultiLineStringTypeExt<'a> as CoordsIterTrait<MultiLineStringTag>>::Iter<'a>,
     ),
     MultiPolygon(<G::MultiPolygonTypeExt<'a> as CoordsIterTrait<MultiPolygonTag>>::Iter<'a>),
-    GeometryCollection(
-        std::vec::IntoIter<Coord<G::T>>,
-    ),
+    GeometryCollection(std::vec::IntoIter<Coord<G::T>>),
     Rect(<G::RectTypeExt<'a> as CoordsIterTrait<RectTag>>::Iter<'a>),
     Triangle(<G::TriangleTypeExt<'a> as CoordsIterTrait<TriangleTag>>::Iter<'a>),
 }
@@ -1254,9 +1254,7 @@ where
     MultiPolygon(
         <G::MultiPolygonTypeExt<'a> as CoordsIterTrait<MultiPolygonTag>>::ExteriorIter<'a>,
     ),
-    GeometryCollection(
-        std::vec::IntoIter<Coord<G::T>>,
-    ),
+    GeometryCollection(std::vec::IntoIter<Coord<G::T>>),
     Rect(<G::RectTypeExt<'a> as CoordsIterTrait<RectTag>>::ExteriorIter<'a>),
     Triangle(<G::TriangleTypeExt<'a> as CoordsIterTrait<TriangleTag>>::ExteriorIter<'a>),
 }

--- a/geo-generic-alg/src/algorithm/coords_iter.rs
+++ b/geo-generic-alg/src/algorithm/coords_iter.rs
@@ -983,6 +983,30 @@ where
     }
 }
 
+fn geometry_coords_count<T, G>(g: &G) -> usize
+where
+    T: CoordNum,
+    G: GeometryTraitExt<T = T>,
+{
+    if g.is_collection() {
+        g.geometries_ext()
+            .map(|g_inner| geometry_coords_count(g_inner.borrow()))
+            .sum()
+    } else {
+        match g.as_type_ext() {
+            GeometryTypeExt::Point(g) => g.coords_count_trait(),
+            GeometryTypeExt::Line(g) => g.coords_count_trait(),
+            GeometryTypeExt::LineString(g) => g.coords_count_trait(),
+            GeometryTypeExt::Polygon(g) => g.coords_count_trait(),
+            GeometryTypeExt::MultiPoint(g) => g.coords_count_trait(),
+            GeometryTypeExt::MultiLineString(g) => g.coords_count_trait(),
+            GeometryTypeExt::MultiPolygon(g) => g.coords_count_trait(),
+            GeometryTypeExt::Rect(g) => g.coords_count_trait(),
+            GeometryTypeExt::Triangle(g) => g.coords_count_trait(),
+        }
+    }
+}
+
 // ┌─────────────────────────────┐
 // │ Implementation for Geometry │
 // └─────────────────────────────┘
@@ -1003,68 +1027,83 @@ where
     type Scalar = T;
 
     fn coords_iter_trait(&self) -> Self::Iter<'_> {
-        match self.as_type_ext() {
-            GeometryTypeExt::Point(g) => GeometryTraitCoordsIter::Point(g.coords_iter_trait()),
-            GeometryTypeExt::Line(g) => GeometryTraitCoordsIter::Line(g.coords_iter_trait()),
-            GeometryTypeExt::LineString(g) => {
-                GeometryTraitCoordsIter::LineString(g.coords_iter_trait())
+        if self.is_collection() {
+            // Boxing is likely necessary here due to heterogeneous nature
+            // and complexity of tracking state across different geometry types
+            // without significant code complexity or allocations anyway.
+            let mut all_coords: Vec<Coord<Self::Scalar>> = Vec::new();
+            for g in self.geometries_ext() {
+                all_coords.extend(g.borrow().coords_iter_trait());
             }
-            GeometryTypeExt::Polygon(g) => GeometryTraitCoordsIter::Polygon(g.coords_iter_trait()),
-            GeometryTypeExt::MultiPoint(g) => {
-                GeometryTraitCoordsIter::MultiPoint(g.coords_iter_trait())
-            }
-            GeometryTypeExt::MultiLineString(g) => {
-                GeometryTraitCoordsIter::MultiLineString(g.coords_iter_trait())
-            }
-            GeometryTypeExt::MultiPolygon(g) => {
-                GeometryTraitCoordsIter::MultiPolygon(g.coords_iter_trait())
-            }
-            // GeometryTypeExt::GeometryCollection(g) => {
-            //     GeometryTraitCoordsIter::GeometryCollection(g.coords_iter_trait())
-            // }
-            GeometryTypeExt::Rect(g) => GeometryTraitCoordsIter::Rect(g.coords_iter_trait()),
-            GeometryTypeExt::Triangle(g) => {
-                GeometryTraitCoordsIter::Triangle(g.coords_iter_trait())
+            let iter = all_coords.into_iter();
+            GeometryTraitCoordsIter::GeometryCollection(iter)
+        } else {
+            match self.as_type_ext() {
+                GeometryTypeExt::Point(g) => GeometryTraitCoordsIter::Point(g.coords_iter_trait()),
+                GeometryTypeExt::Line(g) => GeometryTraitCoordsIter::Line(g.coords_iter_trait()),
+                GeometryTypeExt::LineString(g) => {
+                    GeometryTraitCoordsIter::LineString(g.coords_iter_trait())
+                }
+                GeometryTypeExt::Polygon(g) => GeometryTraitCoordsIter::Polygon(g.coords_iter_trait()),
+                GeometryTypeExt::MultiPoint(g) => {
+                    GeometryTraitCoordsIter::MultiPoint(g.coords_iter_trait())
+                }
+                GeometryTypeExt::MultiLineString(g) => {
+                    GeometryTraitCoordsIter::MultiLineString(g.coords_iter_trait())
+                }
+                GeometryTypeExt::MultiPolygon(g) => {
+                    GeometryTraitCoordsIter::MultiPolygon(g.coords_iter_trait())
+                }
+                GeometryTypeExt::Rect(g) => GeometryTraitCoordsIter::Rect(g.coords_iter_trait()),
+                GeometryTypeExt::Triangle(g) => {
+                    GeometryTraitCoordsIter::Triangle(g.coords_iter_trait())
+                }
             }
         }
     }
 
-    crate::geometry_trait_ext_delegate_impl! {
-        /// Return the number of coordinates in the `Geometry`.
-        fn coords_count_trait(&self) -> usize;
+    /// Return the number of coordinates in the `Geometry`.
+    fn coords_count_trait(&self) -> usize {
+        geometry_coords_count(self)
     }
 
     fn exterior_coords_iter_trait(&self) -> Self::ExteriorIter<'_> {
-        match self.as_type_ext() {
-            GeometryTypeExt::Point(g) => {
-                GeometryTraitExteriorCoordsIter::Point(g.exterior_coords_iter_trait())
+        if self.is_collection() {
+            let mut all_coords: Vec<Coord<Self::Scalar>> = Vec::new();
+            for g in self.geometries_ext() {
+                all_coords.extend(g.borrow().exterior_coords_iter_trait());
             }
-            GeometryTypeExt::Line(g) => {
-                GeometryTraitExteriorCoordsIter::Line(g.exterior_coords_iter_trait())
-            }
-            GeometryTypeExt::LineString(g) => {
-                GeometryTraitExteriorCoordsIter::LineString(g.exterior_coords_iter_trait())
-            }
-            GeometryTypeExt::Polygon(g) => {
-                GeometryTraitExteriorCoordsIter::Polygon(g.exterior_coords_iter_trait())
-            }
-            GeometryTypeExt::MultiPoint(g) => {
-                GeometryTraitExteriorCoordsIter::MultiPoint(g.exterior_coords_iter_trait())
-            }
-            GeometryTypeExt::MultiLineString(g) => {
-                GeometryTraitExteriorCoordsIter::MultiLineString(g.exterior_coords_iter_trait())
-            }
-            GeometryTypeExt::MultiPolygon(g) => {
-                GeometryTraitExteriorCoordsIter::MultiPolygon(g.exterior_coords_iter_trait())
-            }
-            // GeometryTypeExt::GeometryCollection(g) => {
-            //     GeometryTraitExteriorCoordsIter::GeometryCollection(g.exterior_coords_iter_trait())
-            // }
-            GeometryTypeExt::Rect(g) => {
-                GeometryTraitExteriorCoordsIter::Rect(g.exterior_coords_iter_trait())
-            }
-            GeometryTypeExt::Triangle(g) => {
-                GeometryTraitExteriorCoordsIter::Triangle(g.exterior_coords_iter_trait())
+            let iter = all_coords.into_iter();
+            GeometryTraitExteriorCoordsIter::GeometryCollection(iter)
+        } else {
+            match self.as_type_ext() {
+                GeometryTypeExt::Point(g) => {
+                    GeometryTraitExteriorCoordsIter::Point(g.exterior_coords_iter_trait())
+                }
+                GeometryTypeExt::Line(g) => {
+                    GeometryTraitExteriorCoordsIter::Line(g.exterior_coords_iter_trait())
+                }
+                GeometryTypeExt::LineString(g) => {
+                    GeometryTraitExteriorCoordsIter::LineString(g.exterior_coords_iter_trait())
+                }
+                GeometryTypeExt::Polygon(g) => {
+                    GeometryTraitExteriorCoordsIter::Polygon(g.exterior_coords_iter_trait())
+                }
+                GeometryTypeExt::MultiPoint(g) => {
+                    GeometryTraitExteriorCoordsIter::MultiPoint(g.exterior_coords_iter_trait())
+                }
+                GeometryTypeExt::MultiLineString(g) => {
+                    GeometryTraitExteriorCoordsIter::MultiLineString(g.exterior_coords_iter_trait())
+                }
+                GeometryTypeExt::MultiPolygon(g) => {
+                    GeometryTraitExteriorCoordsIter::MultiPolygon(g.exterior_coords_iter_trait())
+                }
+                GeometryTypeExt::Rect(g) => {
+                    GeometryTraitExteriorCoordsIter::Rect(g.exterior_coords_iter_trait())
+                }
+                GeometryTypeExt::Triangle(g) => {
+                    GeometryTraitExteriorCoordsIter::Triangle(g.exterior_coords_iter_trait())
+                }
             }
         }
     }
@@ -1162,9 +1201,9 @@ where
         <G::MultiLineStringTypeExt<'a> as CoordsIterTrait<MultiLineStringTag>>::Iter<'a>,
     ),
     MultiPolygon(<G::MultiPolygonTypeExt<'a> as CoordsIterTrait<MultiPolygonTag>>::Iter<'a>),
-    // GeometryCollection(
-    //     <G::GeometryCollectionTypeExt<'a> as CoordsIterTrait<GeometryCollectionTag>>::Iter<'a>,
-    // ),
+    GeometryCollection(
+        std::vec::IntoIter<Coord<G::T>>,
+    ),
     Rect(<G::RectTypeExt<'a> as CoordsIterTrait<RectTag>>::Iter<'a>),
     Triangle(<G::TriangleTypeExt<'a> as CoordsIterTrait<TriangleTag>>::Iter<'a>),
 }
@@ -1184,7 +1223,7 @@ where
             GeometryTraitCoordsIter::MultiPoint(g) => g.next(),
             GeometryTraitCoordsIter::MultiLineString(g) => g.next(),
             GeometryTraitCoordsIter::MultiPolygon(g) => g.next(),
-            // GeometryTraitCoordsIter::GeometryCollection(g) => g.next(),
+            GeometryTraitCoordsIter::GeometryCollection(g) => g.next(),
             GeometryTraitCoordsIter::Rect(g) => g.next(),
             GeometryTraitCoordsIter::Triangle(g) => g.next(),
         }
@@ -1199,7 +1238,7 @@ where
             GeometryTraitCoordsIter::MultiPoint(g) => g.size_hint(),
             GeometryTraitCoordsIter::MultiLineString(g) => g.size_hint(),
             GeometryTraitCoordsIter::MultiPolygon(g) => g.size_hint(),
-            // GeometryTraitCoordsIter::GeometryCollection(g) => g.size_hint(),
+            GeometryTraitCoordsIter::GeometryCollection(g) => g.size_hint(),
             GeometryTraitCoordsIter::Rect(g) => g.size_hint(),
             GeometryTraitCoordsIter::Triangle(g) => g.size_hint(),
         }
@@ -1228,6 +1267,9 @@ where
     //         'a,
     //     >,
     // ),
+    GeometryCollection(
+        std::vec::IntoIter<Coord<G::T>>,
+    ),
     Rect(<G::RectTypeExt<'a> as CoordsIterTrait<RectTag>>::ExteriorIter<'a>),
     Triangle(<G::TriangleTypeExt<'a> as CoordsIterTrait<TriangleTag>>::ExteriorIter<'a>),
 }
@@ -1247,7 +1289,7 @@ where
             GeometryTraitExteriorCoordsIter::MultiPoint(g) => g.next(),
             GeometryTraitExteriorCoordsIter::MultiLineString(g) => g.next(),
             GeometryTraitExteriorCoordsIter::MultiPolygon(g) => g.next(),
-            // GeometryTraitExteriorCoordsIter::GeometryCollection(g) => g.next(),
+            GeometryTraitExteriorCoordsIter::GeometryCollection(g) => g.next(),
             GeometryTraitExteriorCoordsIter::Rect(g) => g.next(),
             GeometryTraitExteriorCoordsIter::Triangle(g) => g.next(),
         }
@@ -1262,7 +1304,7 @@ where
             GeometryTraitExteriorCoordsIter::MultiPoint(g) => g.size_hint(),
             GeometryTraitExteriorCoordsIter::MultiLineString(g) => g.size_hint(),
             GeometryTraitExteriorCoordsIter::MultiPolygon(g) => g.size_hint(),
-            // GeometryTraitExteriorCoordsIter::GeometryCollection(g) => g.size_hint(),
+            GeometryTraitExteriorCoordsIter::GeometryCollection(g) => g.size_hint(),
             GeometryTraitExteriorCoordsIter::Rect(g) => g.size_hint(),
             GeometryTraitExteriorCoordsIter::Triangle(g) => g.size_hint(),
         }

--- a/geo-generic-alg/src/algorithm/dimensions.rs
+++ b/geo-generic-alg/src/algorithm/dimensions.rs
@@ -1,4 +1,5 @@
 use geo_traits_ext::*;
+use core::borrow::Borrow;
 
 use crate::Orientation::Collinear;
 use crate::{CoordNum, GeoNum, GeometryCow};
@@ -162,14 +163,109 @@ trait HasDimensionsTrait<G: GeoTypeTag> {
     fn boundary_dimensions_trait(&self) -> Dimensions;
 }
 
+fn geometry_is_empty<C, G>(g: &G) -> bool
+where
+    C: GeoNum,
+    G: GeometryTraitExt<T = C>,
+{
+    if g.is_collection() {
+        if g.num_geometries_ext() == 0 {
+            true
+        } else {
+            g.geometries_ext().all(|g_inner| g_inner.borrow().is_empty_trait())
+        }
+    } else {
+        match g.as_type_ext() {
+            GeometryTypeExt::Point(g) => g.is_empty_trait(),
+            GeometryTypeExt::Line(g) => g.is_empty_trait(),
+            GeometryTypeExt::LineString(g) => g.is_empty_trait(),
+            GeometryTypeExt::Polygon(g) => g.is_empty_trait(),
+            GeometryTypeExt::MultiPoint(g) => g.is_empty_trait(),
+            GeometryTypeExt::MultiLineString(g) => g.is_empty_trait(),
+            GeometryTypeExt::MultiPolygon(g) => g.is_empty_trait(),
+            GeometryTypeExt::Rect(g) => g.is_empty_trait(),
+            GeometryTypeExt::Triangle(g) => g.is_empty_trait(),
+        }
+    }
+}
+
+fn geometry_dimensions<C, G>(g: &G) -> Dimensions
+where
+    C: GeoNum,
+    G: GeometryTraitExt<T = C>,
+{
+    if g.is_collection() {
+        let mut max = Dimensions::Empty;
+        for geom in g.geometries_ext() {
+            let dimensions = geom.borrow().dimensions_trait();
+            if dimensions == Dimensions::TwoDimensional {
+                // short-circuit since we know none can be larger
+                return Dimensions::TwoDimensional;
+            }
+            max = max.max(dimensions)
+        }
+        max
+    } else {
+        match g.as_type_ext() {
+            GeometryTypeExt::Point(g) => g.dimensions_trait(),
+            GeometryTypeExt::Line(g) => g.dimensions_trait(),
+            GeometryTypeExt::LineString(g) => g.dimensions_trait(),
+            GeometryTypeExt::Polygon(g) => g.dimensions_trait(),
+            GeometryTypeExt::MultiPoint(g) => g.dimensions_trait(),
+            GeometryTypeExt::MultiLineString(g) => g.dimensions_trait(),
+            GeometryTypeExt::MultiPolygon(g) => g.dimensions_trait(),
+            GeometryTypeExt::Rect(g) => g.dimensions_trait(),
+            GeometryTypeExt::Triangle(g) => g.dimensions_trait(),
+        }
+    }
+}
+
+fn geometry_boundary_dimensions<C, G>(g: &G) -> Dimensions
+where
+    C: GeoNum,
+    G: GeometryTraitExt<T = C>,
+{
+    if g.is_collection() {
+        let mut max = Dimensions::Empty;
+        for geom in g.geometries_ext() {
+            let d = geom.borrow().boundary_dimensions_trait();
+
+            if d == Dimensions::OneDimensional {
+                return Dimensions::OneDimensional;
+            }
+
+            max = max.max(d);
+        }
+        max
+    } else {
+        match g.as_type_ext() {
+            GeometryTypeExt::Point(g) => g.boundary_dimensions_trait(),
+            GeometryTypeExt::Line(g) => g.boundary_dimensions_trait(),
+            GeometryTypeExt::LineString(g) => g.boundary_dimensions_trait(),
+            GeometryTypeExt::Polygon(g) => g.boundary_dimensions_trait(),
+            GeometryTypeExt::MultiPoint(g) => g.boundary_dimensions_trait(),
+            GeometryTypeExt::MultiLineString(g) => g.boundary_dimensions_trait(),
+            GeometryTypeExt::MultiPolygon(g) => g.boundary_dimensions_trait(),
+            GeometryTypeExt::Rect(g) => g.boundary_dimensions_trait(),
+            GeometryTypeExt::Triangle(g) => g.boundary_dimensions_trait(),
+        }
+    }
+}
+
 impl<C: GeoNum, G> HasDimensionsTrait<GeometryTag> for G
 where
     G: GeometryTraitExt<T = C>,
 {
-    crate::geometry_trait_ext_delegate_impl! {
-        fn is_empty_trait(&self) -> bool;
-        fn dimensions_trait(&self) -> Dimensions;
-        fn boundary_dimensions_trait(&self) -> Dimensions;
+    fn is_empty_trait(&self) -> bool {
+        geometry_is_empty(self)
+    }
+
+    fn dimensions_trait(&self) -> Dimensions {
+        geometry_dimensions(self)
+    }
+
+    fn boundary_dimensions_trait(&self) -> Dimensions {
+        geometry_boundary_dimensions(self)
     }
 }
 

--- a/geo-generic-alg/src/algorithm/dimensions.rs
+++ b/geo-generic-alg/src/algorithm/dimensions.rs
@@ -1,5 +1,5 @@
-use geo_traits_ext::*;
 use core::borrow::Borrow;
+use geo_traits_ext::*;
 
 use crate::Orientation::Collinear;
 use crate::{CoordNum, GeoNum, GeometryCow};
@@ -172,7 +172,8 @@ where
             if self.num_geometries_ext() == 0 {
                 true
             } else {
-                self.geometries_ext().all(|g_inner| g_inner.borrow().is_empty_trait())
+                self.geometries_ext()
+                    .all(|g_inner| g_inner.borrow().is_empty_trait())
             }
         } else {
             match self.as_type_ext() {

--- a/geo-generic-alg/src/algorithm/dimensions.rs
+++ b/geo-generic-alg/src/algorithm/dimensions.rs
@@ -163,109 +163,85 @@ trait HasDimensionsTrait<G: GeoTypeTag> {
     fn boundary_dimensions_trait(&self) -> Dimensions;
 }
 
-fn geometry_is_empty<C, G>(g: &G) -> bool
-where
-    C: GeoNum,
-    G: GeometryTraitExt<T = C>,
-{
-    if g.is_collection() {
-        if g.num_geometries_ext() == 0 {
-            true
-        } else {
-            g.geometries_ext().all(|g_inner| g_inner.borrow().is_empty_trait())
-        }
-    } else {
-        match g.as_type_ext() {
-            GeometryTypeExt::Point(g) => g.is_empty_trait(),
-            GeometryTypeExt::Line(g) => g.is_empty_trait(),
-            GeometryTypeExt::LineString(g) => g.is_empty_trait(),
-            GeometryTypeExt::Polygon(g) => g.is_empty_trait(),
-            GeometryTypeExt::MultiPoint(g) => g.is_empty_trait(),
-            GeometryTypeExt::MultiLineString(g) => g.is_empty_trait(),
-            GeometryTypeExt::MultiPolygon(g) => g.is_empty_trait(),
-            GeometryTypeExt::Rect(g) => g.is_empty_trait(),
-            GeometryTypeExt::Triangle(g) => g.is_empty_trait(),
-        }
-    }
-}
-
-fn geometry_dimensions<C, G>(g: &G) -> Dimensions
-where
-    C: GeoNum,
-    G: GeometryTraitExt<T = C>,
-{
-    if g.is_collection() {
-        let mut max = Dimensions::Empty;
-        for geom in g.geometries_ext() {
-            let dimensions = geom.borrow().dimensions_trait();
-            if dimensions == Dimensions::TwoDimensional {
-                // short-circuit since we know none can be larger
-                return Dimensions::TwoDimensional;
-            }
-            max = max.max(dimensions)
-        }
-        max
-    } else {
-        match g.as_type_ext() {
-            GeometryTypeExt::Point(g) => g.dimensions_trait(),
-            GeometryTypeExt::Line(g) => g.dimensions_trait(),
-            GeometryTypeExt::LineString(g) => g.dimensions_trait(),
-            GeometryTypeExt::Polygon(g) => g.dimensions_trait(),
-            GeometryTypeExt::MultiPoint(g) => g.dimensions_trait(),
-            GeometryTypeExt::MultiLineString(g) => g.dimensions_trait(),
-            GeometryTypeExt::MultiPolygon(g) => g.dimensions_trait(),
-            GeometryTypeExt::Rect(g) => g.dimensions_trait(),
-            GeometryTypeExt::Triangle(g) => g.dimensions_trait(),
-        }
-    }
-}
-
-fn geometry_boundary_dimensions<C, G>(g: &G) -> Dimensions
-where
-    C: GeoNum,
-    G: GeometryTraitExt<T = C>,
-{
-    if g.is_collection() {
-        let mut max = Dimensions::Empty;
-        for geom in g.geometries_ext() {
-            let d = geom.borrow().boundary_dimensions_trait();
-
-            if d == Dimensions::OneDimensional {
-                return Dimensions::OneDimensional;
-            }
-
-            max = max.max(d);
-        }
-        max
-    } else {
-        match g.as_type_ext() {
-            GeometryTypeExt::Point(g) => g.boundary_dimensions_trait(),
-            GeometryTypeExt::Line(g) => g.boundary_dimensions_trait(),
-            GeometryTypeExt::LineString(g) => g.boundary_dimensions_trait(),
-            GeometryTypeExt::Polygon(g) => g.boundary_dimensions_trait(),
-            GeometryTypeExt::MultiPoint(g) => g.boundary_dimensions_trait(),
-            GeometryTypeExt::MultiLineString(g) => g.boundary_dimensions_trait(),
-            GeometryTypeExt::MultiPolygon(g) => g.boundary_dimensions_trait(),
-            GeometryTypeExt::Rect(g) => g.boundary_dimensions_trait(),
-            GeometryTypeExt::Triangle(g) => g.boundary_dimensions_trait(),
-        }
-    }
-}
-
 impl<C: GeoNum, G> HasDimensionsTrait<GeometryTag> for G
 where
     G: GeometryTraitExt<T = C>,
 {
     fn is_empty_trait(&self) -> bool {
-        geometry_is_empty(self)
+        if self.is_collection() {
+            if self.num_geometries_ext() == 0 {
+                true
+            } else {
+                self.geometries_ext().all(|g_inner| g_inner.borrow().is_empty_trait())
+            }
+        } else {
+            match self.as_type_ext() {
+                GeometryTypeExt::Point(g) => g.is_empty_trait(),
+                GeometryTypeExt::Line(g) => g.is_empty_trait(),
+                GeometryTypeExt::LineString(g) => g.is_empty_trait(),
+                GeometryTypeExt::Polygon(g) => g.is_empty_trait(),
+                GeometryTypeExt::MultiPoint(g) => g.is_empty_trait(),
+                GeometryTypeExt::MultiLineString(g) => g.is_empty_trait(),
+                GeometryTypeExt::MultiPolygon(g) => g.is_empty_trait(),
+                GeometryTypeExt::Rect(g) => g.is_empty_trait(),
+                GeometryTypeExt::Triangle(g) => g.is_empty_trait(),
+            }
+        }
     }
 
     fn dimensions_trait(&self) -> Dimensions {
-        geometry_dimensions(self)
+        if self.is_collection() {
+            let mut max = Dimensions::Empty;
+            for geom in self.geometries_ext() {
+                let dimensions = geom.borrow().dimensions_trait();
+                if dimensions == Dimensions::TwoDimensional {
+                    // short-circuit since we know none can be larger
+                    return Dimensions::TwoDimensional;
+                }
+                max = max.max(dimensions);
+            }
+            max
+        } else {
+            match self.as_type_ext() {
+                GeometryTypeExt::Point(g) => g.dimensions_trait(),
+                GeometryTypeExt::Line(g) => g.dimensions_trait(),
+                GeometryTypeExt::LineString(g) => g.dimensions_trait(),
+                GeometryTypeExt::Polygon(g) => g.dimensions_trait(),
+                GeometryTypeExt::MultiPoint(g) => g.dimensions_trait(),
+                GeometryTypeExt::MultiLineString(g) => g.dimensions_trait(),
+                GeometryTypeExt::MultiPolygon(g) => g.dimensions_trait(),
+                GeometryTypeExt::Rect(g) => g.dimensions_trait(),
+                GeometryTypeExt::Triangle(g) => g.dimensions_trait(),
+            }
+        }
     }
 
     fn boundary_dimensions_trait(&self) -> Dimensions {
-        geometry_boundary_dimensions(self)
+        if self.is_collection() {
+            let mut max = Dimensions::Empty;
+            for geom in self.geometries_ext() {
+                let d = geom.borrow().boundary_dimensions_trait();
+
+                if d == Dimensions::OneDimensional {
+                    return Dimensions::OneDimensional;
+                }
+
+                max = max.max(d);
+            }
+            max
+        } else {
+            match self.as_type_ext() {
+                GeometryTypeExt::Point(g) => g.boundary_dimensions_trait(),
+                GeometryTypeExt::Line(g) => g.boundary_dimensions_trait(),
+                GeometryTypeExt::LineString(g) => g.boundary_dimensions_trait(),
+                GeometryTypeExt::Polygon(g) => g.boundary_dimensions_trait(),
+                GeometryTypeExt::MultiPoint(g) => g.boundary_dimensions_trait(),
+                GeometryTypeExt::MultiLineString(g) => g.boundary_dimensions_trait(),
+                GeometryTypeExt::MultiPolygon(g) => g.boundary_dimensions_trait(),
+                GeometryTypeExt::Rect(g) => g.boundary_dimensions_trait(),
+                GeometryTypeExt::Triangle(g) => g.boundary_dimensions_trait(),
+            }
+        }
     }
 }
 
@@ -511,7 +487,7 @@ where
                 // short-circuit since we know none can be larger
                 return Dimensions::TwoDimensional;
             }
-            max = max.max(dimensions)
+            max = max.max(dimensions);
         }
         max
     }

--- a/geo-generic-alg/src/algorithm/euclidean_length.rs
+++ b/geo-generic-alg/src/algorithm/euclidean_length.rs
@@ -1,4 +1,5 @@
 use std::iter::Sum;
+use core::borrow::Borrow;
 
 use crate::CoordFloat;
 use geo_traits_ext::*;
@@ -169,19 +170,32 @@ where
         // Linear geometries (lines, linestrings) will contribute their actual length
         // Non-linear geometries (points, polygons) will contribute zero
         self.geometries_ext()
-            .map(|g| match g.as_type_ext() {
-                GeometryTypeExt::Point(_) => T::zero(),
-                GeometryTypeExt::Line(line) => line.euclidean_length_trait(),
-                GeometryTypeExt::LineString(ls) => ls.euclidean_length_trait(),
-                GeometryTypeExt::Polygon(_) => T::zero(),
-                GeometryTypeExt::MultiPoint(_) => T::zero(),
-                GeometryTypeExt::MultiLineString(mls) => mls.euclidean_length_trait(),
-                GeometryTypeExt::MultiPolygon(_) => T::zero(),
-                // GeometryTypeExt::GeometryCollection(gc) => gc.euclidean_length_trait(),
-                GeometryTypeExt::Rect(_) => T::zero(),
-                GeometryTypeExt::Triangle(_) => T::zero(),
-            })
+            .map(|g| geometry_euclidean_length(&g))
             .fold(T::zero(), |acc, next| acc + next)
+    }
+}
+
+fn geometry_euclidean_length<T, G>(g: &G) -> T
+where
+    T: CoordFloat + Sum,
+    G: GeometryTraitExt<T = T>,
+{
+    if g.is_collection() {
+        g.geometries_ext()
+            .map(|g_inner| geometry_euclidean_length(g_inner.borrow()))
+            .fold(T::zero(), |acc, next| acc + next)
+    } else {
+        match g.as_type_ext() {
+            GeometryTypeExt::Point(_) => T::zero(),
+            GeometryTypeExt::Line(line) => line.euclidean_length_trait(),
+            GeometryTypeExt::LineString(ls) => ls.euclidean_length_trait(),
+            GeometryTypeExt::Polygon(_) => T::zero(),
+            GeometryTypeExt::MultiPoint(_) => T::zero(),
+            GeometryTypeExt::MultiLineString(mls) => mls.euclidean_length_trait(),
+            GeometryTypeExt::MultiPolygon(_) => T::zero(),
+            GeometryTypeExt::Rect(_) => T::zero(),
+            GeometryTypeExt::Triangle(_) => T::zero(),
+        }
     }
 }
 
@@ -190,8 +204,8 @@ impl<T, G: GeometryTraitExt<T = T>> EuclideanLengthTrait<T, GeometryTag> for G
 where
     T: CoordFloat + Sum,
 {
-    crate::geometry_trait_ext_delegate_impl! {
-        fn euclidean_length_trait(&self) -> T;
+    fn euclidean_length_trait(&self) -> T {
+        geometry_euclidean_length(self)
     }
 }
 

--- a/geo-generic-alg/src/algorithm/euclidean_length.rs
+++ b/geo-generic-alg/src/algorithm/euclidean_length.rs
@@ -170,32 +170,8 @@ where
         // Linear geometries (lines, linestrings) will contribute their actual length
         // Non-linear geometries (points, polygons) will contribute zero
         self.geometries_ext()
-            .map(|g| geometry_euclidean_length(&g))
+            .map(|g| g.euclidean_length_trait())
             .fold(T::zero(), |acc, next| acc + next)
-    }
-}
-
-fn geometry_euclidean_length<T, G>(g: &G) -> T
-where
-    T: CoordFloat + Sum,
-    G: GeometryTraitExt<T = T>,
-{
-    if g.is_collection() {
-        g.geometries_ext()
-            .map(|g_inner| geometry_euclidean_length(g_inner.borrow()))
-            .fold(T::zero(), |acc, next| acc + next)
-    } else {
-        match g.as_type_ext() {
-            GeometryTypeExt::Point(_) => T::zero(),
-            GeometryTypeExt::Line(line) => line.euclidean_length_trait(),
-            GeometryTypeExt::LineString(ls) => ls.euclidean_length_trait(),
-            GeometryTypeExt::Polygon(_) => T::zero(),
-            GeometryTypeExt::MultiPoint(_) => T::zero(),
-            GeometryTypeExt::MultiLineString(mls) => mls.euclidean_length_trait(),
-            GeometryTypeExt::MultiPolygon(_) => T::zero(),
-            GeometryTypeExt::Rect(_) => T::zero(),
-            GeometryTypeExt::Triangle(_) => T::zero(),
-        }
     }
 }
 
@@ -205,7 +181,23 @@ where
     T: CoordFloat + Sum,
 {
     fn euclidean_length_trait(&self) -> T {
-        geometry_euclidean_length(self)
+        if self.is_collection() {
+            self.geometries_ext()
+                .map(|g_inner| g_inner.borrow().euclidean_length_trait())
+                .fold(T::zero(), |acc, next| acc + next)
+        } else {
+            match self.as_type_ext() {
+                GeometryTypeExt::Point(_) => T::zero(),
+                GeometryTypeExt::Line(line) => line.euclidean_length_trait(),
+                GeometryTypeExt::LineString(ls) => ls.euclidean_length_trait(),
+                GeometryTypeExt::Polygon(_) => T::zero(),
+                GeometryTypeExt::MultiPoint(_) => T::zero(),
+                GeometryTypeExt::MultiLineString(mls) => mls.euclidean_length_trait(),
+                GeometryTypeExt::MultiPolygon(_) => T::zero(),
+                GeometryTypeExt::Rect(_) => T::zero(),
+                GeometryTypeExt::Triangle(_) => T::zero(),
+            }
+        }
     }
 }
 
@@ -382,6 +374,11 @@ mod test {
         // The polygon contributes 0 to the total
         assert_relative_eq!(
             collection.euclidean_length(),
+            2.8284271247461903,
+            epsilon = 1e-10
+        );
+        assert_relative_eq!(
+            Geometry::GeometryCollection(collection).euclidean_length(),
             2.8284271247461903,
             epsilon = 1e-10
         );

--- a/geo-generic-alg/src/algorithm/euclidean_length.rs
+++ b/geo-generic-alg/src/algorithm/euclidean_length.rs
@@ -1,5 +1,5 @@
-use std::iter::Sum;
 use core::borrow::Borrow;
+use std::iter::Sum;
 
 use crate::CoordFloat;
 use geo_traits_ext::*;

--- a/geo-generic-alg/src/algorithm/euclidean_length.rs
+++ b/geo-generic-alg/src/algorithm/euclidean_length.rs
@@ -177,7 +177,7 @@ where
                 GeometryTypeExt::MultiPoint(_) => T::zero(),
                 GeometryTypeExt::MultiLineString(mls) => mls.euclidean_length_trait(),
                 GeometryTypeExt::MultiPolygon(_) => T::zero(),
-                GeometryTypeExt::GeometryCollection(gc) => gc.euclidean_length_trait(),
+                // GeometryTypeExt::GeometryCollection(gc) => gc.euclidean_length_trait(),
                 GeometryTypeExt::Rect(_) => T::zero(),
                 GeometryTypeExt::Triangle(_) => T::zero(),
             })

--- a/geo-generic-alg/src/algorithm/intersects/collections.rs
+++ b/geo-generic-alg/src/algorithm/intersects/collections.rs
@@ -1,5 +1,5 @@
-use geo_traits_ext::*;
 use core::borrow::Borrow;
+use geo_traits_ext::*;
 
 use super::has_disjoint_bboxes;
 use super::IntersectsTrait;

--- a/geo-generic-alg/src/algorithm/intersects/collections.rs
+++ b/geo-generic-alg/src/algorithm/intersects/collections.rs
@@ -1,8 +1,8 @@
 use geo_traits_ext::*;
+use core::borrow::Borrow;
 
 use super::has_disjoint_bboxes;
 use super::IntersectsTrait;
-use crate::geometry_trait_ext_delegate_impl;
 use crate::GeoNum;
 
 macro_rules! impl_intersects_geometry {
@@ -13,8 +13,23 @@ macro_rules! impl_intersects_geometry {
             LHS: GeometryTraitExt<T = T>,
             RHS: $rhs_type<T = T>,
         {
-            geometry_trait_ext_delegate_impl! {
-                fn intersects_trait(&self, rhs: &RHS) -> bool;
+            fn intersects_trait(&self, rhs: &RHS) -> bool {
+                if self.is_collection() {
+                    self.geometries_ext()
+                        .any(|lhs_inner| lhs_inner.borrow().intersects_trait(rhs))
+                } else {
+                    match self.as_type_ext() {
+                        GeometryTypeExt::Point(g) => g.intersects_trait(rhs),
+                        GeometryTypeExt::Line(g) => g.intersects_trait(rhs),
+                        GeometryTypeExt::LineString(g) => g.intersects_trait(rhs),
+                        GeometryTypeExt::Polygon(g) => g.intersects_trait(rhs),
+                        GeometryTypeExt::MultiPoint(g) => g.intersects_trait(rhs),
+                        GeometryTypeExt::MultiLineString(g) => g.intersects_trait(rhs),
+                        GeometryTypeExt::MultiPolygon(g) => g.intersects_trait(rhs),
+                        GeometryTypeExt::Rect(g) => g.intersects_trait(rhs),
+                        GeometryTypeExt::Triangle(g) => g.intersects_trait(rhs),
+                    }
+                }
             }
         }
     };

--- a/geo-generic-alg/src/algorithm/intersects/mod.rs
+++ b/geo-generic-alg/src/algorithm/intersects/mod.rs
@@ -136,7 +136,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use geo_types::Coord;
+    use geo_types::{Coord, GeometryCollection};
 
     use crate::Intersects;
     use crate::{
@@ -547,6 +547,26 @@ mod test {
         );
         assert!(a.intersects(&b));
         assert!(b.intersects(&a));
+    }
+
+    #[test]
+    fn test_geom_collection_collection() {
+        let collection0 = Geometry::GeometryCollection(GeometryCollection::new_from(vec![
+            Geometry::Point(Point::new(0., 0.)),
+            Geometry::Point(Point::new(1., 1.)),
+        ]));
+        let collection1 = Geometry::GeometryCollection(GeometryCollection::new_from(vec![
+            Geometry::Point(Point::new(0., 0.)),
+            Geometry::Point(Point::new(2., 2.)),
+        ]));
+        let collection2 = Geometry::GeometryCollection(GeometryCollection::new_from(vec![
+            Geometry::Point(Point::new(3., 3.)),
+            Geometry::Point(Point::new(4., 4.)),
+        ]));
+        assert!(collection0.intersects(&collection1));
+        assert!(collection1.intersects(&collection0));
+        assert!(!collection0.intersects(&collection2));
+        assert!(!collection2.intersects(&collection0));
     }
 
     #[test]

--- a/geo-generic-alg/src/algorithm/line_measures/length.rs
+++ b/geo-generic-alg/src/algorithm/line_measures/length.rs
@@ -454,18 +454,12 @@ impl<F, G: GeometryTraitExt<T = F>> LengthMeasurableTrait<F, GeometryTag> for G
 where
     F: CoordFloat,
 {
-    // This macro delegates the `length_trait` method to the appropriate geometry variant.
-    // It is critical for WKB (Well-Known Binary) compatibility, ensuring that trait methods
-    // are correctly dispatched for all geometry types when deserializing from WKB.
-    crate::geometry_trait_ext_delegate_impl! {
-        fn length_trait(&self, metric_space: &impl Distance<F, Point<F>, Point<F>>) -> F;
+    fn length_trait(&self, metric_space: &impl Distance<F, Point<F>, Point<F>>) -> F {
+        geometry_length(self, metric_space)
     }
 
-    // This macro delegates the `perimeter_trait` method to the appropriate geometry variant.
-    // It is critical for WKB (Well-Known Binary) compatibility, ensuring that trait methods
-    // are correctly dispatched for all geometry types when deserializing from WKB.
-    crate::geometry_trait_ext_delegate_impl! {
-        fn perimeter_trait(&self, metric_space: &impl Distance<F, Point<F>, Point<F>>) -> F;
+    fn perimeter_trait(&self, metric_space: &impl Distance<F, Point<F>, Point<F>>) -> F {
+        geometry_perimeter(self, metric_space)
     }
 }
 

--- a/geo-generic-alg/src/algorithm/line_measures/length.rs
+++ b/geo-generic-alg/src/algorithm/line_measures/length.rs
@@ -2,6 +2,7 @@ use super::Distance;
 use crate::{CoordFloat, Line, LineString, MultiLineString, Point};
 use geo_traits::{CoordTrait, PolygonTrait};
 use geo_traits_ext::*;
+use std::borrow::Borrow;
 
 /// Calculate the length of a geometry using a given [metric space](crate::algorithm::line_measures::metric_spaces).
 ///
@@ -390,36 +391,62 @@ where
 {
     fn length_trait(&self, metric_space: &impl Distance<F, Point<F>, Point<F>>) -> F {
         self.geometries_ext()
-            .map(|g| match g.as_type_ext() {
-                GeometryTypeExt::Point(_) => F::zero(),
-                GeometryTypeExt::Line(line) => line.length_trait(metric_space),
-                GeometryTypeExt::LineString(ls) => ls.length_trait(metric_space),
-                GeometryTypeExt::Polygon(_) => F::zero(),
-                GeometryTypeExt::MultiPoint(_) => F::zero(),
-                GeometryTypeExt::MultiLineString(mls) => mls.length_trait(metric_space),
-                GeometryTypeExt::MultiPolygon(_) => F::zero(),
-                GeometryTypeExt::GeometryCollection(gc) => gc.length_trait(metric_space),
-                GeometryTypeExt::Rect(_) => F::zero(),
-                GeometryTypeExt::Triangle(_) => F::zero(),
-            })
+            .map(|g| geometry_length(g.borrow(), metric_space))
             .fold(F::zero(), |acc, next| acc + next)
     }
 
     fn perimeter_trait(&self, metric_space: &impl Distance<F, Point<F>, Point<F>>) -> F {
         self.geometries_ext()
-            .map(|g| match g.as_type_ext() {
-                GeometryTypeExt::Point(_) => F::zero(),
-                GeometryTypeExt::Line(_) => F::zero(), // 1D geometry - no perimeter
-                GeometryTypeExt::LineString(_) => F::zero(), // 1D geometry - no perimeter
-                GeometryTypeExt::Polygon(polygon) => polygon.perimeter_trait(metric_space),
-                GeometryTypeExt::MultiPoint(_) => F::zero(),
-                GeometryTypeExt::MultiLineString(_) => F::zero(), // 1D geometry - no perimeter
-                GeometryTypeExt::MultiPolygon(mp) => mp.perimeter_trait(metric_space),
-                GeometryTypeExt::GeometryCollection(gc) => gc.perimeter_trait(metric_space),
-                GeometryTypeExt::Rect(rect) => rect.perimeter_trait(metric_space),
-                GeometryTypeExt::Triangle(triangle) => triangle.perimeter_trait(metric_space),
-            })
+            .map(|g| geometry_perimeter(g.borrow(), metric_space))
             .fold(F::zero(), |acc, next| acc + next)
+    }
+}
+
+fn geometry_length<F, G>(g: &G, metric_space: &impl Distance<F, Point<F>, Point<F>>) -> F
+where
+    F: CoordFloat,
+    G: GeometryTraitExt<T = F>,
+{
+    if g.is_collection() {
+        g.geometries_ext()
+            .map(|g_inner| geometry_length(g_inner.borrow(), metric_space))
+            .fold(F::zero(), |acc, next| acc + next)
+    } else {
+        match g.as_type_ext() {
+            GeometryTypeExt::Point(_) => F::zero(),
+            GeometryTypeExt::Line(line) => line.length_trait(metric_space),
+            GeometryTypeExt::LineString(ls) => ls.length_trait(metric_space),
+            GeometryTypeExt::Polygon(_) => F::zero(),
+            GeometryTypeExt::MultiPoint(_) => F::zero(),
+            GeometryTypeExt::MultiLineString(mls) => mls.length_trait(metric_space),
+            GeometryTypeExt::MultiPolygon(_) => F::zero(),
+            GeometryTypeExt::Rect(_) => F::zero(),
+            GeometryTypeExt::Triangle(_) => F::zero(),
+        }
+    }
+}
+
+fn geometry_perimeter<F, G>(g: &G, metric_space: &impl Distance<F, Point<F>, Point<F>>) -> F
+where
+    F: CoordFloat,
+    G: GeometryTraitExt<T = F>,
+{
+    if g.is_collection() {
+        g.geometries_ext()
+            .map(|g_inner| geometry_perimeter(g_inner.borrow(), metric_space))
+            .fold(F::zero(), |acc, next| acc + next)
+    } else {
+        match g.as_type_ext() {
+            GeometryTypeExt::Point(_) => F::zero(),
+            GeometryTypeExt::Line(_) => F::zero(), // 1D geometry - no perimeter
+            GeometryTypeExt::LineString(_) => F::zero(), // 1D geometry - no perimeter
+            GeometryTypeExt::Polygon(polygon) => polygon.perimeter_trait(metric_space),
+            GeometryTypeExt::MultiPoint(_) => F::zero(),
+            GeometryTypeExt::MultiLineString(_) => F::zero(), // 1D geometry - no perimeter
+            GeometryTypeExt::MultiPolygon(mp) => mp.perimeter_trait(metric_space),
+            GeometryTypeExt::Rect(rect) => rect.perimeter_trait(metric_space),
+            GeometryTypeExt::Triangle(triangle) => triangle.perimeter_trait(metric_space),
+        }
     }
 }
 

--- a/geo-generic-alg/src/algorithm/line_measures/length.rs
+++ b/geo-generic-alg/src/algorithm/line_measures/length.rs
@@ -391,62 +391,14 @@ where
 {
     fn length_trait(&self, metric_space: &impl Distance<F, Point<F>, Point<F>>) -> F {
         self.geometries_ext()
-            .map(|g| geometry_length(g.borrow(), metric_space))
+            .map(|g| g.borrow().length_trait(metric_space))
             .fold(F::zero(), |acc, next| acc + next)
     }
 
     fn perimeter_trait(&self, metric_space: &impl Distance<F, Point<F>, Point<F>>) -> F {
         self.geometries_ext()
-            .map(|g| geometry_perimeter(g.borrow(), metric_space))
+            .map(|g| g.borrow().perimeter_trait(metric_space))
             .fold(F::zero(), |acc, next| acc + next)
-    }
-}
-
-fn geometry_length<F, G>(g: &G, metric_space: &impl Distance<F, Point<F>, Point<F>>) -> F
-where
-    F: CoordFloat,
-    G: GeometryTraitExt<T = F>,
-{
-    if g.is_collection() {
-        g.geometries_ext()
-            .map(|g_inner| geometry_length(g_inner.borrow(), metric_space))
-            .fold(F::zero(), |acc, next| acc + next)
-    } else {
-        match g.as_type_ext() {
-            GeometryTypeExt::Point(_) => F::zero(),
-            GeometryTypeExt::Line(line) => line.length_trait(metric_space),
-            GeometryTypeExt::LineString(ls) => ls.length_trait(metric_space),
-            GeometryTypeExt::Polygon(_) => F::zero(),
-            GeometryTypeExt::MultiPoint(_) => F::zero(),
-            GeometryTypeExt::MultiLineString(mls) => mls.length_trait(metric_space),
-            GeometryTypeExt::MultiPolygon(_) => F::zero(),
-            GeometryTypeExt::Rect(_) => F::zero(),
-            GeometryTypeExt::Triangle(_) => F::zero(),
-        }
-    }
-}
-
-fn geometry_perimeter<F, G>(g: &G, metric_space: &impl Distance<F, Point<F>, Point<F>>) -> F
-where
-    F: CoordFloat,
-    G: GeometryTraitExt<T = F>,
-{
-    if g.is_collection() {
-        g.geometries_ext()
-            .map(|g_inner| geometry_perimeter(g_inner.borrow(), metric_space))
-            .fold(F::zero(), |acc, next| acc + next)
-    } else {
-        match g.as_type_ext() {
-            GeometryTypeExt::Point(_) => F::zero(),
-            GeometryTypeExt::Line(_) => F::zero(), // 1D geometry - no perimeter
-            GeometryTypeExt::LineString(_) => F::zero(), // 1D geometry - no perimeter
-            GeometryTypeExt::Polygon(polygon) => polygon.perimeter_trait(metric_space),
-            GeometryTypeExt::MultiPoint(_) => F::zero(),
-            GeometryTypeExt::MultiLineString(_) => F::zero(), // 1D geometry - no perimeter
-            GeometryTypeExt::MultiPolygon(mp) => mp.perimeter_trait(metric_space),
-            GeometryTypeExt::Rect(rect) => rect.perimeter_trait(metric_space),
-            GeometryTypeExt::Triangle(triangle) => triangle.perimeter_trait(metric_space),
-        }
     }
 }
 
@@ -455,11 +407,43 @@ where
     F: CoordFloat,
 {
     fn length_trait(&self, metric_space: &impl Distance<F, Point<F>, Point<F>>) -> F {
-        geometry_length(self, metric_space)
+        if self.is_collection() {
+            self.geometries_ext()
+                .map(|g_inner| g_inner.borrow().length_trait(metric_space))
+                .fold(F::zero(), |acc, next| acc + next)
+        } else {
+            match self.as_type_ext() {
+                GeometryTypeExt::Point(_) => F::zero(),
+                GeometryTypeExt::Line(line) => line.length_trait(metric_space),
+                GeometryTypeExt::LineString(ls) => ls.length_trait(metric_space),
+                GeometryTypeExt::Polygon(_) => F::zero(),
+                GeometryTypeExt::MultiPoint(_) => F::zero(),
+                GeometryTypeExt::MultiLineString(mls) => mls.length_trait(metric_space),
+                GeometryTypeExt::MultiPolygon(_) => F::zero(),
+                GeometryTypeExt::Rect(_) => F::zero(),
+                GeometryTypeExt::Triangle(_) => F::zero(),
+            }
+        }
     }
 
     fn perimeter_trait(&self, metric_space: &impl Distance<F, Point<F>, Point<F>>) -> F {
-        geometry_perimeter(self, metric_space)
+        if self.is_collection() {
+            self.geometries_ext()
+                .map(|g_inner| g_inner.borrow().perimeter_trait(metric_space))
+                .fold(F::zero(), |acc, next| acc + next)
+        } else {
+            match self.as_type_ext() {
+                GeometryTypeExt::Point(_) => F::zero(),
+                GeometryTypeExt::Line(_) => F::zero(), // 1D geometry - no perimeter
+                GeometryTypeExt::LineString(_) => F::zero(), // 1D geometry - no perimeter
+                GeometryTypeExt::Polygon(polygon) => polygon.perimeter_trait(metric_space),
+                GeometryTypeExt::MultiPoint(_) => F::zero(),
+                GeometryTypeExt::MultiLineString(_) => F::zero(), // 1D geometry - no perimeter
+                GeometryTypeExt::MultiPolygon(mp) => mp.perimeter_trait(metric_space),
+                GeometryTypeExt::Rect(rect) => rect.perimeter_trait(metric_space),
+                GeometryTypeExt::Triangle(triangle) => triangle.perimeter_trait(metric_space),
+            }
+        }
     }
 }
 
@@ -709,6 +693,13 @@ mod tests {
                 2.8284271247461903, // 2*sqrt(2) only from linestrings
                 epsilon = 1e-10
             );
+
+            // GEOMETRY representation of GEOMETRYCOLLECTION
+            assert_relative_eq!(
+                Geometry::GeometryCollection(collection.clone()).length_ext(&Euclidean),
+                2.8284271247461903, // 2*sqrt(2) only from linestrings
+                epsilon = 1e-10
+            );
         }
 
         #[test]
@@ -794,6 +785,13 @@ mod tests {
             ]);
             assert_relative_eq!(
                 collection.perimeter_ext(&Euclidean),
+                4.0, // only polygon perimeter counts
+                epsilon = 1e-10
+            );
+
+            // GEOMETRY representation of GEOMETRYCOLLECTION
+            assert_relative_eq!(
+                Geometry::GeometryCollection(collection).perimeter_ext(&Euclidean),
                 4.0, // only polygon perimeter counts
                 epsilon = 1e-10
             );

--- a/geo-generic-alg/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
+++ b/geo-generic-alg/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
@@ -2,7 +2,7 @@ use super::{Distance, Euclidean};
 use crate::algorithm::Intersects;
 use crate::geometry::*;
 use crate::{Coord, CoordFloat, GeoFloat, Point};
-use geo_traits::to_geo::ToGeoGeometry;
+// use geo_traits::to_geo::ToGeoGeometry;
 use num_traits::{Bounded, Float};
 
 // Import all the utility functions from utils module
@@ -1148,27 +1148,28 @@ where
     RHS: GeometryCollectionTraitExt<T = F>,
 {
     fn generic_distance_trait(&self, rhs: &RHS) -> F {
-        use num_traits::Bounded;
+        // use num_traits::Bounded;
 
-        let mut min_distance = <F as Bounded>::max_value();
+        // let mut min_distance = <F as Bounded>::max_value();
 
-        for lhs_geom in self.geometries_ext() {
-            for rhs_geom in rhs.geometries_ext() {
-                // Convert to concrete types for this specific case only
-                // This avoids the trait bound complexity while still using generic traits everywhere else
-                let lhs_concrete = lhs_geom.to_geometry();
-                let rhs_concrete = rhs_geom.to_geometry();
-                let distance = Euclidean.distance(&lhs_concrete, &rhs_concrete);
-                min_distance = min_distance.min(distance);
+        // for lhs_geom in self.geometries_ext() {
+        //     for rhs_geom in rhs.geometries_ext() {
+        //         // Convert to concrete types for this specific case only
+        //         // This avoids the trait bound complexity while still using generic traits everywhere else
+        //         let lhs_concrete = lhs_geom.to_geometry();
+        //         let rhs_concrete = rhs_geom.to_geometry();
+        //         let distance = Euclidean.distance(&lhs_concrete, &rhs_concrete);
+        //         min_distance = min_distance.min(distance);
 
-                // Early exit optimization
-                if distance == F::zero() {
-                    return F::zero();
-                }
-            }
-        }
+        //         // Early exit optimization
+        //         if distance == F::zero() {
+        //             return F::zero();
+        //         }
+        //     }
+        // }
 
-        min_distance
+        // min_distance
+        unimplemented!()
     }
 }
 
@@ -1283,27 +1284,21 @@ where
                             left.distance_ext(right)
                         },
                     )+)+
-                    _ => {
-                        let g1 = self.to_geometry();
-                        let g2 = rhs.to_geometry();
-                        Euclidean.distance(&g1, &g2)
-                    }
                 }
             };
         }
 
         // Generate the match with explicit left => [right types] mappings
         generate_distance_match!(
-            Point => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection],
-            Line => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection],
-            LineString => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection],
-            Polygon => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection],
-            Triangle => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection],
-            Rect => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection],
-            MultiPoint => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection],
-            MultiLineString => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection],
-            MultiPolygon => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection],
-            GeometryCollection => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
+            Point => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
+            Line => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
+            LineString => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
+            Polygon => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
+            Triangle => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
+            Rect => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
+            MultiPoint => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
+            MultiLineString => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
+            MultiPolygon => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
         )
     }
 }

--- a/geo-generic-alg/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
+++ b/geo-generic-alg/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
@@ -2,8 +2,8 @@ use super::{Distance, Euclidean};
 use crate::algorithm::Intersects;
 use crate::geometry::*;
 use crate::{Coord, CoordFloat, GeoFloat, Point};
-// use geo_traits::to_geo::ToGeoGeometry;
 use num_traits::{Bounded, Float};
+use std::borrow::Borrow;
 
 // Import all the utility functions from utils module
 use super::utils::{
@@ -391,12 +391,13 @@ pub trait DistanceExt<F: CoordFloat, Rhs = Self> {
 macro_rules! impl_distance_ext_for_polygonlike_geometry_trait {
     ($polygonlike_trait:ident, $polygonlike_tag:ident, [$(($geometry_trait:ident, $geometry_tag:ident)),*]) => {
         // Self-to-self distance implementation
-        impl<F, P: $polygonlike_trait<T = F>>
-            GenericDistanceTrait<F, $polygonlike_tag, $polygonlike_tag, P> for P
+        impl<F, LHS, RHS> GenericDistanceTrait<F, $polygonlike_tag, $polygonlike_tag, RHS> for LHS
         where
             F: GeoFloat,
+            LHS: $polygonlike_trait<T = F>,
+            RHS: $polygonlike_trait<T = F>,
         {
-            fn generic_distance_trait(&self, rhs: &P) -> F {
+            fn generic_distance_trait(&self, rhs: &RHS) -> F {
                 let poly1 = self.to_polygon();
                 let poly2 = rhs.to_polygon();
                 distance_polygon_to_polygon_generic(&poly1, &poly2)
@@ -494,11 +495,13 @@ macro_rules! impl_polygonlike_to_geometry_distance {
 /// Follows the same pattern as impl_euclidean_distance_for_iter_geometry!
 macro_rules! impl_distance_ext_for_iter_geometry_trait {
     ($iter_trait:ident, $iter_tag:ident, $member_method:ident) => {
-        impl<F, I: $iter_trait<T = F>> GenericDistanceTrait<F, $iter_tag, $iter_tag, I> for I
+        impl<F, LHS, RHS> GenericDistanceTrait<F, $iter_tag, $iter_tag, RHS> for LHS
         where
             F: GeoFloat,
+            LHS: $iter_trait<T = F>,
+            RHS: $iter_trait<T = F>,
         {
-            fn generic_distance_trait(&self, rhs: &I) -> F {
+            fn generic_distance_trait(&self, rhs: &RHS) -> F {
                 let mut min_dist: F = Float::max_value();
                 for member1 in self.$member_method() {
                     for member2 in rhs.$member_method() {
@@ -664,11 +667,13 @@ where
 // └────────────────────────────────────────────────────────────┘
 
 // Point-to-Point direct distance implementation
-impl<F, P: PointTraitExt<T = F>> GenericDistanceTrait<F, PointTag, PointTag, P> for P
+impl<F, LHS, RHS> GenericDistanceTrait<F, PointTag, PointTag, RHS> for LHS
 where
     F: GeoFloat,
+    LHS: PointTraitExt<T = F>,
+    RHS: PointTraitExt<T = F>,
 {
-    fn generic_distance_trait(&self, rhs: &P) -> F {
+    fn generic_distance_trait(&self, rhs: &RHS) -> F {
         distance_point_to_point_generic(self, rhs)
     }
 }
@@ -747,11 +752,13 @@ symmetric_distance_ext_trait_impl!(GeoFloat, LineTraitExt, LineTag, CoordTraitEx
 symmetric_distance_ext_trait_impl!(GeoFloat, LineTraitExt, LineTag, PointTraitExt, PointTag);
 
 // Line-to-Line direct distance implementation
-impl<F, L: LineTraitExt<T = F>> GenericDistanceTrait<F, LineTag, LineTag, L> for L
+impl<F, LHS, RHS> GenericDistanceTrait<F, LineTag, LineTag, RHS> for LHS
 where
     F: GeoFloat,
+    LHS: LineTraitExt<T = F>,
+    RHS: LineTraitExt<T = F>,
 {
-    fn generic_distance_trait(&self, rhs: &L) -> F {
+    fn generic_distance_trait(&self, rhs: &RHS) -> F {
         distance_line_to_line_generic(self, rhs)
     }
 }
@@ -1140,36 +1147,28 @@ impl_distance_geometry_collection_from_geometry!(MultiLineStringTraitExt, MultiL
 impl_distance_geometry_collection_from_geometry!(MultiPolygonTraitExt, MultiPolygonTag);
 impl_distance_geometry_collection_from_geometry!(RectTraitExt, RectTag);
 impl_distance_geometry_collection_from_geometry!(TriangleTraitExt, TriangleTag);
-// Manual implementation for GeometryCollection to GeometryCollection to avoid infinite recursion
+
 impl<F, LHS, RHS> GenericDistanceTrait<F, GeometryCollectionTag, GeometryCollectionTag, RHS> for LHS
 where
     F: GeoFloat,
     LHS: GeometryCollectionTraitExt<T = F>,
     RHS: GeometryCollectionTraitExt<T = F>,
 {
-    fn generic_distance_trait(&self, _rhs: &RHS) -> F {
-        // use num_traits::Bounded;
+    fn generic_distance_trait(&self, rhs: &RHS) -> F {
+        let mut min_distance = <F as Bounded>::max_value();
+        for lhs_geom in self.geometries_ext() {
+            for rhs_geom in rhs.geometries_ext() {
+                let distance = lhs_geom.distance_ext(&rhs_geom);
+                min_distance = min_distance.min(distance);
 
-        // let mut min_distance = <F as Bounded>::max_value();
+                // Early exit optimization
+                if distance == F::zero() {
+                    return F::zero();
+                }
+            }
+        }
 
-        // for lhs_geom in self.geometries_ext() {
-        //     for rhs_geom in rhs.geometries_ext() {
-        //         // Convert to concrete types for this specific case only
-        //         // This avoids the trait bound complexity while still using generic traits everywhere else
-        //         let lhs_concrete = lhs_geom.to_geometry();
-        //         let rhs_concrete = rhs_geom.to_geometry();
-        //         let distance = Euclidean.distance(&lhs_concrete, &rhs_concrete);
-        //         min_distance = min_distance.min(distance);
-
-        //         // Early exit optimization
-        //         if distance == F::zero() {
-        //             return F::zero();
-        //         }
-        //     }
-        // }
-
-        // min_distance
-        unimplemented!()
+        min_distance
     }
 }
 
@@ -1251,7 +1250,44 @@ macro_rules! impl_distance_geometry_to_type {
             RHS: $rhs_type<T = F>,
         {
             fn generic_distance_trait(&self, rhs: &RHS) -> F {
-                self.distance_ext(rhs)
+                if self.is_collection() {
+                    let mut min_distance = <F as Bounded>::max_value();
+                    for lhs_geom in self.geometries_ext() {
+                        let lhs_geom = lhs_geom.borrow();
+                        let distance = lhs_geom.generic_distance_trait(rhs);
+                        min_distance = min_distance.min(distance);
+
+                        // Early exit optimization
+                        if distance == F::zero() {
+                            return F::zero();
+                        }
+                    }
+                    min_distance
+                } else {
+                    match self.as_type_ext() {
+                        geo_traits_ext::GeometryTypeExt::Point(g) => g.generic_distance_trait(rhs),
+                        geo_traits_ext::GeometryTypeExt::Line(g) => g.generic_distance_trait(rhs),
+                        geo_traits_ext::GeometryTypeExt::LineString(g) => {
+                            g.generic_distance_trait(rhs)
+                        }
+                        geo_traits_ext::GeometryTypeExt::Polygon(g) => {
+                            g.generic_distance_trait(rhs)
+                        }
+                        geo_traits_ext::GeometryTypeExt::MultiPoint(g) => {
+                            g.generic_distance_trait(rhs)
+                        }
+                        geo_traits_ext::GeometryTypeExt::MultiLineString(g) => {
+                            g.generic_distance_trait(rhs)
+                        }
+                        geo_traits_ext::GeometryTypeExt::MultiPolygon(g) => {
+                            g.generic_distance_trait(rhs)
+                        }
+                        geo_traits_ext::GeometryTypeExt::Rect(g) => g.generic_distance_trait(rhs),
+                        geo_traits_ext::GeometryTypeExt::Triangle(g) => {
+                            g.generic_distance_trait(rhs)
+                        }
+                    }
+                }
             }
         }
     };
@@ -1268,38 +1304,112 @@ impl_distance_geometry_to_type!(RectTraitExt, RectTag);
 impl_distance_geometry_to_type!(TriangleTraitExt, TriangleTag);
 impl_distance_geometry_to_type!(GeometryCollectionTraitExt, GeometryCollectionTag);
 
-impl<F, G: GeometryTraitExt<T = F>> GenericDistanceTrait<F, GeometryTag, GeometryTag, G> for G
+symmetric_distance_ext_trait_impl!(
+    GeoFloat,
+    PointTraitExt,
+    PointTag,
+    GeometryTraitExt,
+    GeometryTag
+);
+symmetric_distance_ext_trait_impl!(
+    GeoFloat,
+    LineTraitExt,
+    LineTag,
+    GeometryTraitExt,
+    GeometryTag
+);
+symmetric_distance_ext_trait_impl!(
+    GeoFloat,
+    LineStringTraitExt,
+    LineStringTag,
+    GeometryTraitExt,
+    GeometryTag
+);
+symmetric_distance_ext_trait_impl!(
+    GeoFloat,
+    PolygonTraitExt,
+    PolygonTag,
+    GeometryTraitExt,
+    GeometryTag
+);
+symmetric_distance_ext_trait_impl!(
+    GeoFloat,
+    MultiPointTraitExt,
+    MultiPointTag,
+    GeometryTraitExt,
+    GeometryTag
+);
+symmetric_distance_ext_trait_impl!(
+    GeoFloat,
+    MultiLineStringTraitExt,
+    MultiLineStringTag,
+    GeometryTraitExt,
+    GeometryTag
+);
+symmetric_distance_ext_trait_impl!(
+    GeoFloat,
+    MultiPolygonTraitExt,
+    MultiPolygonTag,
+    GeometryTraitExt,
+    GeometryTag
+);
+symmetric_distance_ext_trait_impl!(
+    GeoFloat,
+    RectTraitExt,
+    RectTag,
+    GeometryTraitExt,
+    GeometryTag
+);
+symmetric_distance_ext_trait_impl!(
+    GeoFloat,
+    TriangleTraitExt,
+    TriangleTag,
+    GeometryTraitExt,
+    GeometryTag
+);
+symmetric_distance_ext_trait_impl!(
+    GeoFloat,
+    GeometryCollectionTraitExt,
+    GeometryCollectionTag,
+    GeometryTraitExt,
+    GeometryTag
+);
+
+impl<F, LHS, RHS> GenericDistanceTrait<F, GeometryTag, GeometryTag, RHS> for LHS
 where
     F: GeoFloat,
+    LHS: GeometryTraitExt<T = F>,
+    RHS: GeometryTraitExt<T = F>,
 {
-    fn generic_distance_trait(&self, rhs: &G) -> F {
-        use geo_traits_ext::GeometryTypeExt;
+    fn generic_distance_trait(&self, rhs: &RHS) -> F {
+        if self.is_collection() {
+            let mut min_distance = <F as Bounded>::max_value();
+            for lhs_geom in self.geometries_ext() {
+                let lhs_geom = lhs_geom.borrow();
+                let distance = lhs_geom.generic_distance_trait(rhs);
+                min_distance = min_distance.min(distance);
 
-        // This macro generates the entire match statement
-        macro_rules! generate_distance_match {
-            ($($left:ident => [$($right:ident),+]),+ $(,)?) => {
-                match (self.as_type_ext(), rhs.as_type_ext()) {
-                    $($(
-                        (GeometryTypeExt::$left(left), GeometryTypeExt::$right(right)) => {
-                            left.distance_ext(right)
-                        },
-                    )+)+
+                // Early exit optimization
+                if distance == F::zero() {
+                    return F::zero();
                 }
-            };
+            }
+            min_distance
+        } else {
+            match self.as_type_ext() {
+                geo_traits_ext::GeometryTypeExt::Point(g) => g.generic_distance_trait(rhs),
+                geo_traits_ext::GeometryTypeExt::Line(g) => g.generic_distance_trait(rhs),
+                geo_traits_ext::GeometryTypeExt::LineString(g) => g.generic_distance_trait(rhs),
+                geo_traits_ext::GeometryTypeExt::Polygon(g) => g.generic_distance_trait(rhs),
+                geo_traits_ext::GeometryTypeExt::MultiPoint(g) => g.generic_distance_trait(rhs),
+                geo_traits_ext::GeometryTypeExt::MultiLineString(g) => {
+                    g.generic_distance_trait(rhs)
+                }
+                geo_traits_ext::GeometryTypeExt::MultiPolygon(g) => g.generic_distance_trait(rhs),
+                geo_traits_ext::GeometryTypeExt::Rect(g) => g.generic_distance_trait(rhs),
+                geo_traits_ext::GeometryTypeExt::Triangle(g) => g.generic_distance_trait(rhs),
+            }
         }
-
-        // Generate the match with explicit left => [right types] mappings
-        generate_distance_match!(
-            Point => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
-            Line => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
-            LineString => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
-            Polygon => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
-            Triangle => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
-            Rect => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
-            MultiPoint => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
-            MultiLineString => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
-            MultiPolygon => [Point, Line, LineString, Polygon, Triangle, Rect, MultiPoint, MultiLineString, MultiPolygon],
-        )
     }
 }
 
@@ -2440,7 +2550,6 @@ mod tests {
 
         #[test]
         fn test_original_issue_verification() {
-            // This test verifies the fix for the segmentation fault issue reported in SedonaDB:
             let point = Point::new(0.0, 0.0);
             let linestring = LineString::from(vec![(0.0, 0.0), (1.0, 1.0)]);
 
@@ -2454,12 +2563,6 @@ mod tests {
                 Geometry::LineString(linestring),
             ]);
 
-            // Before our fix: This would cause infinite recursion because:
-            // 1. GeometryCollection calls distance_ext on each geometry
-            // 2. When geometry is another GeometryCollection, it calls distance_ext again
-            // 3. This triggers the same GeometryCollection implementation → infinite recursion
-            // 4. Stack overflow → segmentation fault
-
             // Test the concrete Distance API
             let distance = Euclidean.distance(&gc1, &gc2);
             assert_eq!(
@@ -2467,7 +2570,7 @@ mod tests {
                 "Distance between identical GeometryCollections should be 0"
             );
 
-            // Test the generic distance_ext API directly (this should trigger the problematic path)
+            // Test the generic distance_ext API directly
             use crate::line_measures::DistanceExt;
             let distance_ext = gc1.distance_ext(&gc2);
             assert_eq!(distance_ext, 0.0, "Generic distance should also be 0");
@@ -2488,8 +2591,18 @@ mod tests {
                 Geometry::LineString(linestring),
             ]);
 
-            // Force the generic trait path by calling distance_ext on trait objects
             let distance_result = gc1.distance_ext(&gc2);
+            assert_eq!(distance_result, 0.0);
+
+            let geom_gc1 = Geometry::GeometryCollection(gc1.clone());
+            let geom_gc2 = Geometry::GeometryCollection(gc2.clone());
+            let distance_result = geom_gc1.distance_ext(&geom_gc2);
+            assert_eq!(distance_result, 0.0);
+
+            let distance_result = geom_gc1.distance_ext(&gc2);
+            assert_eq!(distance_result, 0.0);
+
+            let distance_result = gc1.distance_ext(&geom_gc2);
             assert_eq!(distance_result, 0.0);
         }
     }

--- a/geo-generic-alg/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
+++ b/geo-generic-alg/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
@@ -1147,7 +1147,7 @@ where
     LHS: GeometryCollectionTraitExt<T = F>,
     RHS: GeometryCollectionTraitExt<T = F>,
 {
-    fn generic_distance_trait(&self, rhs: &RHS) -> F {
+    fn generic_distance_trait(&self, _rhs: &RHS) -> F {
         // use num_traits::Bounded;
 
         // let mut min_distance = <F as Bounded>::max_value();

--- a/geo-generic-alg/src/algorithm/map_coords.rs
+++ b/geo-generic-alg/src/algorithm/map_coords.rs
@@ -27,9 +27,9 @@
 pub(crate) use crate::geometry::*;
 pub(crate) use crate::CoordNum;
 
+use core::borrow::Borrow;
 use geo_traits_ext::*;
 use Coord;
-use core::borrow::Borrow;
 
 /// Map a function over all the coordinates in an object, returning a new one
 pub trait MapCoords<T: CoordNum, NT: CoordNum> {
@@ -592,7 +592,11 @@ where
 
     fn map_coords_trait(&self, func: impl Fn(Coord<T>) -> Coord<NT> + Copy) -> Self::Output {
         if self.is_collection() {
-            let collection = GeometryCollection::new_from(self.geometries_ext().map(|g| g.borrow().map_coords(func)).collect());
+            let collection = GeometryCollection::new_from(
+                self.geometries_ext()
+                    .map(|g| g.borrow().map_coords(func))
+                    .collect(),
+            );
             Geometry::GeometryCollection(collection)
         } else {
             match self.as_type_ext() {
@@ -604,7 +608,9 @@ where
                 GeometryTypeExt::MultiLineString(x) => {
                     Geometry::MultiLineString(x.map_coords_trait(func))
                 }
-                GeometryTypeExt::MultiPolygon(x) => Geometry::MultiPolygon(x.map_coords_trait(func)),
+                GeometryTypeExt::MultiPolygon(x) => {
+                    Geometry::MultiPolygon(x.map_coords_trait(func))
+                }
                 GeometryTypeExt::Rect(x) => Geometry::Rect(x.map_coords_trait(func)),
                 GeometryTypeExt::Triangle(x) => Geometry::Triangle(x.map_coords_trait(func)),
             }
@@ -616,9 +622,10 @@ where
         func: impl Fn(Coord<T>) -> Result<Coord<NT>, E> + Copy,
     ) -> Result<Self::Output, E> {
         if self.is_collection() {
-            let geoms = self.geometries_ext()
-                    .map(|g| g.borrow().try_map_coords(func))
-                    .collect::<Result<Vec<_>, E>>()?;
+            let geoms = self
+                .geometries_ext()
+                .map(|g| g.borrow().try_map_coords(func))
+                .collect::<Result<Vec<_>, E>>()?;
             let collection = GeometryCollection::new_from(geoms);
             Ok(Geometry::GeometryCollection(collection))
         } else {
@@ -639,7 +646,9 @@ where
                     Ok(Geometry::MultiPolygon(x.try_map_coords_trait(func)?))
                 }
                 GeometryTypeExt::Rect(x) => Ok(Geometry::Rect(x.try_map_coords_trait(func)?)),
-                GeometryTypeExt::Triangle(x) => Ok(Geometry::Triangle(x.try_map_coords_trait(func)?)),
+                GeometryTypeExt::Triangle(x) => {
+                    Ok(Geometry::Triangle(x.try_map_coords_trait(func)?))
+                }
             }
         }
     }
@@ -1060,7 +1069,8 @@ mod test {
             expected
         );
         assert_eq!(
-            Geometry::GeometryCollection(gc).map_coords(|Coord { x, y }| (x + 10., y + 100.).into()),
+            Geometry::GeometryCollection(gc)
+                .map_coords(|Coord { x, y }| (x + 10., y + 100.).into()),
             Geometry::GeometryCollection(expected)
         );
     }

--- a/geo-generic-alg/src/algorithm/map_coords.rs
+++ b/geo-generic-alg/src/algorithm/map_coords.rs
@@ -29,6 +29,7 @@ pub(crate) use crate::CoordNum;
 
 use geo_traits_ext::*;
 use Coord;
+use core::borrow::Borrow;
 
 /// Map a function over all the coordinates in an object, returning a new one
 pub trait MapCoords<T: CoordNum, NT: CoordNum> {
@@ -590,21 +591,23 @@ where
     type Output = Geometry<NT>;
 
     fn map_coords_trait(&self, func: impl Fn(Coord<T>) -> Coord<NT> + Copy) -> Self::Output {
-        match self.as_type_ext() {
-            GeometryTypeExt::Point(x) => Geometry::Point(x.map_coords_trait(func)),
-            GeometryTypeExt::Line(x) => Geometry::Line(x.map_coords_trait(func)),
-            GeometryTypeExt::LineString(x) => Geometry::LineString(x.map_coords_trait(func)),
-            GeometryTypeExt::Polygon(x) => Geometry::Polygon(x.map_coords_trait(func)),
-            GeometryTypeExt::MultiPoint(x) => Geometry::MultiPoint(x.map_coords_trait(func)),
-            GeometryTypeExt::MultiLineString(x) => {
-                Geometry::MultiLineString(x.map_coords_trait(func))
+        if self.is_collection() {
+            let collection = GeometryCollection::new_from(self.geometries_ext().map(|g| g.borrow().map_coords(func)).collect());
+            Geometry::GeometryCollection(collection)
+        } else {
+            match self.as_type_ext() {
+                GeometryTypeExt::Point(x) => Geometry::Point(x.map_coords_trait(func)),
+                GeometryTypeExt::Line(x) => Geometry::Line(x.map_coords_trait(func)),
+                GeometryTypeExt::LineString(x) => Geometry::LineString(x.map_coords_trait(func)),
+                GeometryTypeExt::Polygon(x) => Geometry::Polygon(x.map_coords_trait(func)),
+                GeometryTypeExt::MultiPoint(x) => Geometry::MultiPoint(x.map_coords_trait(func)),
+                GeometryTypeExt::MultiLineString(x) => {
+                    Geometry::MultiLineString(x.map_coords_trait(func))
+                }
+                GeometryTypeExt::MultiPolygon(x) => Geometry::MultiPolygon(x.map_coords_trait(func)),
+                GeometryTypeExt::Rect(x) => Geometry::Rect(x.map_coords_trait(func)),
+                GeometryTypeExt::Triangle(x) => Geometry::Triangle(x.map_coords_trait(func)),
             }
-            GeometryTypeExt::MultiPolygon(x) => Geometry::MultiPolygon(x.map_coords_trait(func)),
-            // GeometryTypeExt::GeometryCollection(x) => {
-            //     Geometry::GeometryCollection(x.map_coords_trait(func))
-            // }
-            GeometryTypeExt::Rect(x) => Geometry::Rect(x.map_coords_trait(func)),
-            GeometryTypeExt::Triangle(x) => Geometry::Triangle(x.map_coords_trait(func)),
         }
     }
 
@@ -612,27 +615,32 @@ where
         &self,
         func: impl Fn(Coord<T>) -> Result<Coord<NT>, E> + Copy,
     ) -> Result<Self::Output, E> {
-        match self.as_type_ext() {
-            GeometryTypeExt::Point(x) => Ok(Geometry::Point(x.try_map_coords_trait(func)?)),
-            GeometryTypeExt::Line(x) => Ok(Geometry::Line(x.try_map_coords_trait(func)?)),
-            GeometryTypeExt::LineString(x) => {
-                Ok(Geometry::LineString(x.try_map_coords_trait(func)?))
+        if self.is_collection() {
+            let geoms = self.geometries_ext()
+                    .map(|g| g.borrow().try_map_coords(func))
+                    .collect::<Result<Vec<_>, E>>()?;
+            let collection = GeometryCollection::new_from(geoms);
+            Ok(Geometry::GeometryCollection(collection))
+        } else {
+            match self.as_type_ext() {
+                GeometryTypeExt::Point(x) => Ok(Geometry::Point(x.try_map_coords_trait(func)?)),
+                GeometryTypeExt::Line(x) => Ok(Geometry::Line(x.try_map_coords_trait(func)?)),
+                GeometryTypeExt::LineString(x) => {
+                    Ok(Geometry::LineString(x.try_map_coords_trait(func)?))
+                }
+                GeometryTypeExt::Polygon(x) => Ok(Geometry::Polygon(x.try_map_coords_trait(func)?)),
+                GeometryTypeExt::MultiPoint(x) => {
+                    Ok(Geometry::MultiPoint(x.try_map_coords_trait(func)?))
+                }
+                GeometryTypeExt::MultiLineString(x) => {
+                    Ok(Geometry::MultiLineString(x.try_map_coords_trait(func)?))
+                }
+                GeometryTypeExt::MultiPolygon(x) => {
+                    Ok(Geometry::MultiPolygon(x.try_map_coords_trait(func)?))
+                }
+                GeometryTypeExt::Rect(x) => Ok(Geometry::Rect(x.try_map_coords_trait(func)?)),
+                GeometryTypeExt::Triangle(x) => Ok(Geometry::Triangle(x.try_map_coords_trait(func)?)),
             }
-            GeometryTypeExt::Polygon(x) => Ok(Geometry::Polygon(x.try_map_coords_trait(func)?)),
-            GeometryTypeExt::MultiPoint(x) => {
-                Ok(Geometry::MultiPoint(x.try_map_coords_trait(func)?))
-            }
-            GeometryTypeExt::MultiLineString(x) => {
-                Ok(Geometry::MultiLineString(x.try_map_coords_trait(func)?))
-            }
-            GeometryTypeExt::MultiPolygon(x) => {
-                Ok(Geometry::MultiPolygon(x.try_map_coords_trait(func)?))
-            }
-            // GeometryTypeExt::GeometryCollection(x) => {
-            //     Ok(Geometry::GeometryCollection(x.try_map_coords_trait(func)?))
-            // }
-            GeometryTypeExt::Rect(x) => Ok(Geometry::Rect(x.try_map_coords_trait(func)?)),
-            GeometryTypeExt::Triangle(x) => Ok(Geometry::Triangle(x.try_map_coords_trait(func)?)),
         }
     }
 }
@@ -1042,13 +1050,18 @@ mod test {
         let line1 = Geometry::LineString(LineString::from(vec![(0., 0.), (1., 2.)]));
 
         let gc = GeometryCollection::new_from(vec![p1, line1]);
+        let expected = GeometryCollection::new_from(vec![
+            Geometry::Point(Point::new(20., 110.)),
+            Geometry::LineString(LineString::from(vec![(10., 100.), (11., 102.)])),
+        ]);
 
         assert_eq!(
             gc.map_coords(|Coord { x, y }| (x + 10., y + 100.).into()),
-            GeometryCollection::new_from(vec![
-                Geometry::Point(Point::new(20., 110.)),
-                Geometry::LineString(LineString::from(vec![(10., 100.), (11., 102.)])),
-            ])
+            expected
+        );
+        assert_eq!(
+            Geometry::GeometryCollection(gc).map_coords(|Coord { x, y }| (x + 10., y + 100.).into()),
+            Geometry::GeometryCollection(expected)
         );
     }
 

--- a/geo-generic-alg/src/algorithm/map_coords.rs
+++ b/geo-generic-alg/src/algorithm/map_coords.rs
@@ -600,9 +600,9 @@ where
                 Geometry::MultiLineString(x.map_coords_trait(func))
             }
             GeometryTypeExt::MultiPolygon(x) => Geometry::MultiPolygon(x.map_coords_trait(func)),
-            GeometryTypeExt::GeometryCollection(x) => {
-                Geometry::GeometryCollection(x.map_coords_trait(func))
-            }
+            // GeometryTypeExt::GeometryCollection(x) => {
+            //     Geometry::GeometryCollection(x.map_coords_trait(func))
+            // }
             GeometryTypeExt::Rect(x) => Geometry::Rect(x.map_coords_trait(func)),
             GeometryTypeExt::Triangle(x) => Geometry::Triangle(x.map_coords_trait(func)),
         }
@@ -628,9 +628,9 @@ where
             GeometryTypeExt::MultiPolygon(x) => {
                 Ok(Geometry::MultiPolygon(x.try_map_coords_trait(func)?))
             }
-            GeometryTypeExt::GeometryCollection(x) => {
-                Ok(Geometry::GeometryCollection(x.try_map_coords_trait(func)?))
-            }
+            // GeometryTypeExt::GeometryCollection(x) => {
+            //     Ok(Geometry::GeometryCollection(x.try_map_coords_trait(func)?))
+            // }
             GeometryTypeExt::Rect(x) => Ok(Geometry::Rect(x.try_map_coords_trait(func)?)),
             GeometryTypeExt::Triangle(x) => Ok(Geometry::Triangle(x.try_map_coords_trait(func)?)),
         }

--- a/geo-generic-alg/src/types.rs
+++ b/geo-generic-alg/src/types.rs
@@ -183,7 +183,7 @@ macro_rules! __geometry_trait_ext_delegate_impl_helper {
                         $enum::MultiPoint(g) => g.$func_name($($arg_name),*).into(),
                         $enum::MultiLineString(g) => g.$func_name($($arg_name),*).into(),
                         $enum::MultiPolygon(g) => g.$func_name($($arg_name),*).into(),
-                        $enum::GeometryCollection(g) => g.$func_name($($arg_name),*).into(),
+                        // $enum::GeometryCollection(g) => g.$func_name($($arg_name),*).into(),
                         $enum::Rect(g) => g.$func_name($($arg_name),*).into(),
                         $enum::Triangle(g) => g.$func_name($($arg_name),*).into(),
                     }

--- a/geo-generic-alg/src/types.rs
+++ b/geo-generic-alg/src/types.rs
@@ -156,38 +156,3 @@ macro_rules! __geometry_delegate_impl_helper {
             )+
         };
 }
-
-#[macro_export]
-macro_rules! geometry_trait_ext_delegate_impl {
-    ($($a:tt)*) => { $crate::__geometry_trait_ext_delegate_impl_helper!{ GeometryTypeExt, $($a)* } }
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __geometry_trait_ext_delegate_impl_helper {
-    (
-        $enum:ident,
-        $(
-            $(#[$outer:meta])*
-            fn $func_name: ident(&$($self_life:lifetime)?self $(, $arg_name: ident: $arg_type: ty)*) -> $return: ty;
-         )+
-    ) => {
-            $(
-                $(#[$outer])*
-                fn $func_name(&$($self_life)? self, $($arg_name: $arg_type),*) -> $return {
-                    match self.as_type_ext() {
-                        $enum::Point(g) => g.$func_name($($arg_name),*).into(),
-                        $enum::Line(g) =>  g.$func_name($($arg_name),*).into(),
-                        $enum::LineString(g) => g.$func_name($($arg_name),*).into(),
-                        $enum::Polygon(g) => g.$func_name($($arg_name),*).into(),
-                        $enum::MultiPoint(g) => g.$func_name($($arg_name),*).into(),
-                        $enum::MultiLineString(g) => g.$func_name($($arg_name),*).into(),
-                        $enum::MultiPolygon(g) => g.$func_name($($arg_name),*).into(),
-                        // $enum::GeometryCollection(g) => g.$func_name($($arg_name),*).into(),
-                        $enum::Rect(g) => g.$func_name($($arg_name),*).into(),
-                        $enum::Triangle(g) => g.$func_name($($arg_name),*).into(),
-                    }
-                }
-            )+
-        };
-}

--- a/geo-generic-tests/src/simple/geometry.rs
+++ b/geo-generic-tests/src/simple/geometry.rs
@@ -173,8 +173,29 @@ impl<T: CoordNum> GeometryTrait for SimpleGeometry<T> {
     }
 }
 
-impl<T: CoordNum> GeometryTraitExt for &SimpleGeometry<T> {
+impl<'a, T: CoordNum> GeometryTraitExt for &'a SimpleGeometry<T> {
     forward_geometry_trait_ext_funcs!(T);
+
+    type InnerGeometryRef<'b>
+        = &'a SimpleGeometry<T>
+    where
+        Self: 'b;
+
+    fn geometry_ext(&self, _i: usize) -> Option<Self::InnerGeometryRef<'_>> {
+        None
+    }
+
+    unsafe fn geometry_unchecked_ext(&self, _i: usize) -> Self::InnerGeometryRef<'_> {
+        unimplemented!()
+    }
+
+    fn geometries_ext(&self) -> impl Iterator<Item = Self::InnerGeometryRef<'_>> {
+        unimplemented!();
+
+        // For making the type checker happy
+        #[allow(unreachable_code)]
+        core::iter::empty()
+    }
 }
 
 impl<T: CoordNum> GeoTraitExtWithTypeTag for &SimpleGeometry<T> {
@@ -183,6 +204,27 @@ impl<T: CoordNum> GeoTraitExtWithTypeTag for &SimpleGeometry<T> {
 
 impl<T: CoordNum> GeometryTraitExt for SimpleGeometry<T> {
     forward_geometry_trait_ext_funcs!(T);
+
+    type InnerGeometryRef<'a>
+        = &'a SimpleGeometry<T>
+    where
+        Self: 'a;
+
+    fn geometry_ext(&self, _i: usize) -> Option<Self::InnerGeometryRef<'_>> {
+        None
+    }
+
+    unsafe fn geometry_unchecked_ext(&self, _i: usize) -> Self::InnerGeometryRef<'_> {
+        unimplemented!()
+    }
+
+    fn geometries_ext(&self) -> impl Iterator<Item = Self::InnerGeometryRef<'_>> {
+        unimplemented!();
+
+        // For making the type checker happy
+        #[allow(unreachable_code)]
+        core::iter::empty()
+    }
 }
 
 impl<T: CoordNum> GeoTraitExtWithTypeTag for SimpleGeometry<T> {

--- a/geo-generic-tests/src/wkb/reader/geometry.rs
+++ b/geo-generic-tests/src/wkb/reader/geometry.rs
@@ -13,8 +13,8 @@ use crate::wkb::reader::{
 };
 use crate::wkb::Endianness;
 use geo_traits::{
-    Dimensions, GeometryTrait, GeometryType, UnimplementedLine, UnimplementedRect,
-    UnimplementedTriangle,
+    Dimensions, GeometryCollectionTrait, GeometryTrait, GeometryType, UnimplementedLine,
+    UnimplementedRect, UnimplementedTriangle,
 };
 
 use super::linearring::WKBLinearRing;
@@ -263,8 +263,34 @@ impl<'a> GeometryTrait for &Wkb<'a> {
     }
 }
 
-impl GeometryTraitExt for Wkb<'_> {
+impl<'a> GeometryTraitExt for Wkb<'a> {
     forward_geometry_trait_ext_funcs!(f64);
+
+    type InnerGeometryRef<'b>
+        = &'b Wkb<'a>
+    where
+        Self: 'b;
+
+    fn geometry_ext(&self, i: usize) -> Option<Self::InnerGeometryRef<'_>> {
+        let GeometryType::GeometryCollection(gc) = self.as_type() else {
+            return None;
+        };
+        gc.geometry(i)
+    }
+
+    unsafe fn geometry_unchecked_ext(&self, i: usize) -> Self::InnerGeometryRef<'_> {
+        let GeometryType::GeometryCollection(gc) = self.as_type() else {
+            panic!("Called geometry_unchecked_ext on a non-GeometryCollection geometry");
+        };
+        gc.geometry_unchecked(i)
+    }
+
+    fn geometries_ext(&self) -> impl Iterator<Item = Self::InnerGeometryRef<'_>> {
+        let GeometryType::GeometryCollection(gc) = self.as_type() else {
+            panic!("Called geometries_ext on a non-GeometryCollection geometry");
+        };
+        gc.geometries()
+    }
 }
 
 impl<'a, 'b> GeometryTraitExt for &'b Wkb<'a>
@@ -272,6 +298,26 @@ where
     'a: 'b,
 {
     forward_geometry_trait_ext_funcs!(f64);
+
+    type InnerGeometryRef<'c>
+        = &'b Wkb<'a>
+    where
+        Self: 'c;
+
+    fn geometry_ext(&self, i: usize) -> Option<Self::InnerGeometryRef<'_>> {
+        let g = *self;
+        g.geometry_ext(i)
+    }
+
+    unsafe fn geometry_unchecked_ext(&self, i: usize) -> Self::InnerGeometryRef<'_> {
+        let g = *self;
+        g.geometry_unchecked_ext(i)
+    }
+
+    fn geometries_ext(&self) -> impl Iterator<Item = Self::InnerGeometryRef<'_>> {
+        let g = *self;
+        g.geometries_ext()
+    }
 }
 
 impl GeoTraitExtWithTypeTag for Wkb<'_> {

--- a/geo-traits-ext/src/geometry.rs
+++ b/geo-traits-ext/src/geometry.rs
@@ -65,6 +65,14 @@ where
         matches!(self.as_type(), GeometryType::GeometryCollection(_))
     }
 
+    /// Returns the number of geometries inside this GeometryCollection
+    fn num_geometries_ext(&self) -> usize {
+        let GeometryType::GeometryCollection(gc) = self.as_type() else {
+            panic!("Not a GeometryCollection");
+        };
+        gc.num_geometries()
+    }
+
     /// Cast this geometry to a [`GeometryTypeExt`] enum, which allows for downcasting to a specific
     /// type. This does not work when the geometry is a GeometryCollection. Please use `is_collection`
     /// to check if the geometry is NOT a GeometryCollection first before calling this method.
@@ -228,7 +236,7 @@ where
 
     fn geometry_ext(&self, i: usize) -> Option<&Geometry<T>> {
         let GeometryType::GeometryCollection(gc) = self.as_type() else {
-            return None;
+            panic!("Not a GeometryCollection");
         };
         gc.geometry(i)
     }

--- a/geo-traits-ext/src/geometry.rs
+++ b/geo-traits-ext/src/geometry.rs
@@ -54,7 +54,9 @@ where
     // See also https://github.com/geoarrow/geoarrow-rs/issues/1339.
     //
     // Although this could be worked around by not implementing generic functions using trait-based approach and use
-    // function-based approach instead, see https://github.com/geoarrow/geoarrow-rs/pull/956 and https://github.com/georust/wkb/pull/77.
+    // function-based approach instead, see https://github.com/geoarrow/geoarrow-rs/pull/956 and https://github.com/georust/wkb/pull/77,
+    // we are not certain if there will be other issues caused by recursive GATs in the future. So we decided to completely get rid
+    // of recursive GATs.
 
     type InnerGeometryRef<'a>: 'a + Borrow<Self>
     where

--- a/geo-traits-ext/src/geometry.rs
+++ b/geo-traits-ext/src/geometry.rs
@@ -1,5 +1,7 @@
 // Extend GeometryTrait traits for the `geo-traits` crate
 
+use core::{borrow::Borrow, panic};
+
 use geo_traits::*;
 use geo_types::*;
 
@@ -46,11 +48,26 @@ where
     where
         Self: 'a;
 
-    type GeometryCollectionTypeExt<'a>: 'a
-        + GeometryCollectionTraitExt<T = <Self as GeometryTrait>::T>
+    // Note that we don't have a GeometryCollectionTypeExt here, because it would introduce recursive GATs
+    // such as G::GeometryCollectionTypeExt::GeometryTypeExt::GeometryCollectionTypeExt::... and easily
+    // trigger a Rust compiler bug: https://github.com/rust-lang/rust/issues/128887 and https://github.com/rust-lang/rust/issues/131960.
+    // See also https://github.com/geoarrow/geoarrow-rs/issues/1339.
+    //
+    // Although this could be worked around by not implementing generic functions using trait-based approach and use
+    // function-based approach instead, see https://github.com/geoarrow/geoarrow-rs/pull/956 and https://github.com/georust/wkb/pull/77.
+
+    type InnerGeometryRef<'a>: 'a + Borrow<Self>
     where
         Self: 'a;
 
+    /// Returns true if this geometry is a GeometryCollection
+    fn is_collection(&self) -> bool {
+        matches!(self.as_type(), GeometryType::GeometryCollection(_))
+    }
+
+    /// Cast this geometry to a [`GeometryTypeExt`] enum, which allows for downcasting to a specific
+    /// type. This does not work when the geometry is a GeometryCollection. Please use `is_collection`
+    /// to check if the geometry is NOT a GeometryCollection first before calling this method.
     fn as_type_ext(
         &self,
     ) -> GeometryTypeExt<
@@ -61,15 +78,32 @@ where
         Self::MultiPointTypeExt<'_>,
         Self::MultiLineStringTypeExt<'_>,
         Self::MultiPolygonTypeExt<'_>,
-        Self::GeometryCollectionTypeExt<'_>,
         Self::RectTypeExt<'_>,
         Self::TriangleTypeExt<'_>,
         Self::LineTypeExt<'_>,
     >;
+
+    /// Returns a geometry by index, or None if the index is out of bounds. This method only works with
+    /// GeometryCollection. Please use `is_collection` to check if the geometry is a GeometryCollection first before
+    /// calling this method.
+    fn geometry_ext(&self, i: usize) -> Option<Self::InnerGeometryRef<'_>>;
+
+    /// Returns a geometry by index without bounds checking. This method only works with GeometryCollection.
+    /// Please use `is_collection` to check if the geometry is a GeometryCollection first before calling this method.
+    ///
+    /// # Safety
+    /// The caller must ensure that `i` is a valid index less than the number of geometries.
+    /// Otherwise, this function may cause undefined behavior.
+    unsafe fn geometry_unchecked_ext(&self, i: usize) -> Self::InnerGeometryRef<'_>;
+
+    /// Returns an iterator over the geometries in this GeometryCollection. This method only works with
+    /// GeometryCollection. Please use `is_collection` to check if the geometry is a GeometryCollection first before
+    /// calling this method.
+    fn geometries_ext(&self) -> impl Iterator<Item = Self::InnerGeometryRef<'_>>;
 }
 
 #[derive(Debug)]
-pub enum GeometryTypeExt<'a, P, LS, Y, MP, ML, MY, GC, R, TT, L>
+pub enum GeometryTypeExt<'a, P, LS, Y, MP, ML, MY, R, TT, L>
 where
     P: PointTraitExt,
     LS: LineStringTraitExt,
@@ -77,7 +111,6 @@ where
     MP: MultiPointTraitExt,
     ML: MultiLineStringTraitExt,
     MY: MultiPolygonTraitExt,
-    GC: GeometryCollectionTraitExt,
     R: RectTraitExt,
     TT: TriangleTraitExt,
     L: LineTraitExt,
@@ -87,7 +120,6 @@ where
     <MP as GeometryTrait>::T: CoordNum,
     <ML as GeometryTrait>::T: CoordNum,
     <MY as GeometryTrait>::T: CoordNum,
-    <GC as GeometryTrait>::T: CoordNum,
     <R as GeometryTrait>::T: CoordNum,
     <TT as GeometryTrait>::T: CoordNum,
     <L as GeometryTrait>::T: CoordNum,
@@ -98,7 +130,6 @@ where
     MultiPoint(&'a MP),
     MultiLineString(&'a ML),
     MultiPolygon(&'a MY),
-    GeometryCollection(&'a GC),
     Rect(&'a R),
     Triangle(&'a TT),
     Line(&'a L),
@@ -137,11 +168,6 @@ macro_rules! forward_geometry_trait_ext_funcs {
         where
             Self: '__g_inner;
 
-        type GeometryCollectionTypeExt<'__g_inner>
-            = <Self as GeometryTrait>::GeometryCollectionType<'__g_inner>
-        where
-            Self: '__g_inner;
-
         type RectTypeExt<'__g_inner>
             = <Self as GeometryTrait>::RectType<'__g_inner>
         where
@@ -167,7 +193,6 @@ macro_rules! forward_geometry_trait_ext_funcs {
             Self::MultiPointTypeExt<'_>,
             Self::MultiLineStringTypeExt<'_>,
             Self::MultiPolygonTypeExt<'_>,
-            Self::GeometryCollectionTypeExt<'_>,
             Self::RectTypeExt<'_>,
             Self::TriangleTypeExt<'_>,
             Self::LineTypeExt<'_>,
@@ -179,7 +204,9 @@ macro_rules! forward_geometry_trait_ext_funcs {
                 GeometryType::MultiPoint(mp) => GeometryTypeExt::MultiPoint(mp),
                 GeometryType::MultiLineString(mls) => GeometryTypeExt::MultiLineString(mls),
                 GeometryType::MultiPolygon(mp) => GeometryTypeExt::MultiPolygon(mp),
-                GeometryType::GeometryCollection(gc) => GeometryTypeExt::GeometryCollection(gc),
+                GeometryType::GeometryCollection(_) => {
+                    panic!("GeometryCollection is not supported in GeometryTraitExt::as_type_ext")
+                }
                 GeometryType::Rect(r) => GeometryTypeExt::Rect(r),
                 GeometryType::Triangle(t) => GeometryTypeExt::Triangle(t),
                 GeometryType::Line(l) => GeometryTypeExt::Line(l),
@@ -193,17 +220,63 @@ where
     T: CoordNum,
 {
     forward_geometry_trait_ext_funcs!(T);
+
+    type InnerGeometryRef<'a>
+        = &'a Geometry<T>
+    where
+        Self: 'a;
+
+    fn geometry_ext(&self, i: usize) -> Option<&Geometry<T>> {
+        let GeometryType::GeometryCollection(gc) = self.as_type() else {
+            return None;
+        };
+        gc.geometry(i)
+    }
+
+    unsafe fn geometry_unchecked_ext(&self, i: usize) -> &Geometry<T> {
+        let GeometryType::GeometryCollection(gc) = self.as_type() else {
+            panic!("Not a GeometryCollection");
+        };
+        gc.geometry_unchecked(i)
+    }
+
+    fn geometries_ext(&self) -> impl Iterator<Item = &Geometry<T>> {
+        let GeometryType::GeometryCollection(gc) = self.as_type() else {
+            panic!("Not a GeometryCollection");
+        };
+        gc.geometries()
+    }
 }
 
 impl<T: CoordNum> GeoTraitExtWithTypeTag for Geometry<T> {
     type Tag = GeometryTag;
 }
 
-impl<T> GeometryTraitExt for &Geometry<T>
+impl<'a, T> GeometryTraitExt for &'a Geometry<T>
 where
     T: CoordNum,
 {
     forward_geometry_trait_ext_funcs!(T);
+
+    type InnerGeometryRef<'b>
+        = &'a Geometry<T>
+    where
+        Self: 'b;
+
+    fn geometry_ext(&self, i: usize) -> Option<&'a Geometry<T>> {
+        let g = *self;
+        g.geometry_ext(i)
+    }
+
+    unsafe fn geometry_unchecked_ext(&self, i: usize) -> &'a Geometry<T> {
+        let g = *self;
+        g.geometry_unchecked_ext(i)
+    }
+
+    fn geometries_ext(&self) -> impl Iterator<Item = &'a Geometry<T>> {
+        let g = *self;
+        g.geometries_ext()
+    }
 }
 
 impl<T: CoordNum> GeoTraitExtWithTypeTag for &Geometry<T> {
@@ -215,6 +288,27 @@ where
     T: CoordNum,
 {
     forward_geometry_trait_ext_funcs!(T);
+
+    type InnerGeometryRef<'a>
+        = &'a UnimplementedGeometry<T>
+    where
+        Self: 'a;
+
+    fn geometry_ext(&self, _i: usize) -> Option<Self::InnerGeometryRef<'_>> {
+        unimplemented!()
+    }
+
+    unsafe fn geometry_unchecked_ext(&self, _i: usize) -> Self::InnerGeometryRef<'_> {
+        unimplemented!()
+    }
+
+    fn geometries_ext(&self) -> impl Iterator<Item = Self::InnerGeometryRef<'_>> {
+        unimplemented!();
+
+        // For making the type checker happy
+        #[allow(unreachable_code)]
+        core::iter::empty()
+    }
 }
 
 impl<T: CoordNum> GeoTraitExtWithTypeTag for UnimplementedGeometry<T> {


### PR DESCRIPTION
This patch removes the GAT `GeometryCollectionTypeExt` from `GeometryTraitExt` because it would introduce recursive GATs such as `G::GeometryCollectionTypeExt::GeometryTypeExt::GeometryCollectionTypeExt::...` and easily
trigger a Rust compiler bug: https://github.com/rust-lang/rust/issues/128887 and https://github.com/rust-lang/rust/issues/131960. See also https://github.com/geoarrow/geoarrow-rs/issues/1339.

Although this could be worked around by not implementing generic functions using trait-based approach and use
function-based approach instead, see https://github.com/geoarrow/geoarrow-rs/pull/956 and https://github.com/georust/wkb/pull/77, we are not certain if there will be other issues caused by recursive GATs in the future. So we decided to completely get rid of recursive GATs.